### PR TITLE
support string argument for sensor accessor methods 

### DIFF
--- a/euscollada/src/euscollada-robot.l
+++ b/euscollada/src/euscollada-robot.l
@@ -46,6 +46,8 @@
                                   ((keywordp (car args))
                                    ;;(warn ";; no such sensor ~A~%" (car args))
                                    nil)
+                                  ((stringp (car args))
+                                   (find-if #'(lambda (x) (string= (send x :name) (car args))) (send self ,(read-from-string (format nil "~As" sensor-name)))))
                                   (t
                                    (forward-message-to (car (send self ,(read-from-string (format nil "~As" sensor-name)))) args)
                                    )))

--- a/euscollada/src/euscollada-robot_urdfmodel.l
+++ b/euscollada/src/euscollada-robot_urdfmodel.l
@@ -37,6 +37,8 @@
                                   ((keywordp (car args))
                                    ;;(warn ";; no such sensor ~A~%" (car args))
                                    nil)
+                                  ((stringp (car args))
+                                   (find-if #'(lambda (x) (string= (send x :name) (car args))) (send self ,(read-from-string (format nil "~As" sensor-name)))))
                                   (t
                                    (forward-message-to (car (send self ,(read-from-string (format nil "~As" sensor-name)))) args)
                                    )))


### PR DESCRIPTION
Support string argument for sensor accessor methods 
discussed in https://github.com/jsk-ros-pkg/jsk_model_tools/issues/18.
