### PR TITLE
Remove deprecate sensor methods

### DIFF
--- a/euscollada/src/euscollada-robot.l
+++ b/euscollada/src/euscollada-robot.l
@@ -26,32 +26,7 @@
      (send (send j :child-link) :add-joint j)
      (send (send j :child-link) :add-parent-link (send j :parent-link))
      (send (send j :parent-link) :add-child-links (send j :child-link)))
-   ;; add sensor method ;; e.g., (send self :camera 0), (send self :force-sensor :rasensor), ... etc
-   (dolist (sensor-name '(:force-sensor :imu-sensor)) (send self :define-get-sensor-method sensor-name))
    )
-  (:define-get-sensor-method
-   (sensor-name)
-   (eval `(defmethod ,(send (class self) :name)
-              (,sensor-name (&rest args)
-                            (cond ((integerp (car args))
-                                   (forward-message-to (elt (send self ,(read-from-string (format nil "~As" sensor-name)) ) (car args)) (cdr args)))
-                                  ;; enable to access sensors by limb name
-                                  ((memq (car args) '(:larm :rarm :lleg :rleg :head :torso))
-                                   (find-if
-                                    #'(lambda (x) (member (send x :parent) (send self (car args) :links)))
-                                    (send self ,(read-from-string (format nil "~As" sensor-name)))))
-                                  ((and (keywordp (car args))
-                                        (derivedp (send self (car args)) cascaded-coords))
-                                   (send* self args))
-                                  ((keywordp (car args))
-                                   ;;(warn ";; no such sensor ~A~%" (car args))
-                                   nil)
-                                  ((stringp (car args))
-                                   (find-if #'(lambda (x) (string= (send x :name) (car args))) (send self ,(read-from-string (format nil "~As" sensor-name)))))
-                                  (t
-                                   (forward-message-to (car (send self ,(read-from-string (format nil "~As" sensor-name)))) args)
-                                   )))
-              )))
   ;; fullbody-inverse-kinematics overwrite
   ;;  reduce root-link's weight based on leg's joint limit
   ;;  increase stop and cog-gain

--- a/euscollada/src/euscollada-robot_urdfmodel.l
+++ b/euscollada/src/euscollada-robot_urdfmodel.l
@@ -16,33 +16,7 @@
      (send (send j :child-link) :add-joint j)
      (send (send j :child-link) :add-parent-link (send j :parent-link))
      (send (send j :parent-link) :add-child-links (send j :child-link)))
-   ;; add sensor method ;; e.g., (send self :camera 0), (send self :force-sensor :rasensor), ... etc
-   (dolist (sensor-name '(:force-sensor :imu-sensor))
-     (send self :define-get-sensor-method sensor-name))
    )
-  (:define-get-sensor-method
-   (sensor-name)
-   (eval `(defmethod ,(send (class self) :name)
-              (,sensor-name (&rest args)
-                            (cond ((integerp (car args))
-                                   (forward-message-to (elt (send self ,(read-from-string (format nil "~As" sensor-name)) ) (car args)) (cdr args)))
-                                  ;; enable to access sensors by limb name
-                                  ((memq (car args) '(:larm :rarm :lleg :rleg :head :torso))
-                                   (find-if
-                                    #'(lambda (x) (member (send x :parent) (send self (car args) :links)))
-                                    (send self ,(read-from-string (format nil "~As" sensor-name)))))
-                                  ((and (keywordp (car args))
-                                        (derivedp (send self (car args)) cascaded-coords))
-                                   (send* self args))
-                                  ((keywordp (car args))
-                                   ;;(warn ";; no such sensor ~A~%" (car args))
-                                   nil)
-                                  ((stringp (car args))
-                                   (find-if #'(lambda (x) (string= (send x :name) (car args))) (send self ,(read-from-string (format nil "~As" sensor-name)))))
-                                  (t
-                                   (forward-message-to (car (send self ,(read-from-string (format nil "~As" sensor-name)))) args)
-                                   )))
-              )))
   ;; fullbody-inverse-kinematics overwrite
   ;;  reduce root-link's weight based on leg's joint limit
   ;;  increase stop and cog-gain


### PR DESCRIPTION
Remove deprecate sensor methods.
Latest sensor methods are added and testes by https://github.com/euslisp/jskeus/pull/92
Problems are originally reported in jsk-ros-pkg/jsk_model_tools/issues/18.
