### PR TITLE
Add dependency on pr2-common (pr2_mechanism_model) for euscollada conversion test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,12 @@ matrix:
   allow_failures:
     - env: ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=true
     - env: ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=false
+before_install: # Use this to prepare the system to install prerequisites or dependencies
+  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
+  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+  - sudo apt-get update -qq
+install:
+  - sudo apt-get install -qq -y ros-$ROS_DISTRO-pr2-mechanism;
 script: source .travis/travis.sh
 notifications:
   email:

--- a/euscollada/CMakeLists.txt
+++ b/euscollada/CMakeLists.txt
@@ -72,7 +72,7 @@ convert_to_collada()
 
 ## pr2.l
 rosbuild_find_ros_package(pr2_mechanism_model)
-if(pr2_mechanism_model_FOUND)
+if(EXISTS "${pr2_mechanism_model_PACKAGE_PATH}")
   ADD_CUSTOM_COMMAND(
     OUTPUT ${CMAKE_SOURCE_DIR}/pr2.l
     COMMAND rosrun euscollada pr2.sh

--- a/euscollada/pr2.sh
+++ b/euscollada/pr2.sh
@@ -9,38 +9,36 @@ if [ "$?" != 0 ] ;  then exit ; fi
 rosrun euscollada collada2eus pr2.dae pr2.yaml pr2.l.$$.tmp; mv pr2.l.$$.tmp pr2.l
 if [ "$?" != 0 ] ;  then exit ; fi
 
-# rosrun roseus roseus "\
-# (progn									\
-#   (load \"package://euscollada/pr2.l\")					\
-#   (load \"package://pr2eus/pr2-utils.l\")				\
-#   (if (and x::*display* (> x::*display* 0) (not (boundp '*irtviewer*))) (make-irtviewer :title \"pr2.sh\"))			\
-#   (if (not (boundp '*pr2*)) (pr2))					\
-# 									\
-#   (send *pr2* :move-to (make-coords) :world)				\
-#   (send *pr2* :reset-pose)						\
-#   (when (boundp '*irtviewer*) (objects (list *pr2*)))			\
-#   (setq i 0)								\
-#   (do-until-key								\
-#    (print (list i (send *pr2* :torso :waist-z :joint-angle)))		\
-#    (setq p (make-coords :pos						\
-#                         (v+ (float-vector 400 -400 1000)		\
-#                             (float-vector				\
-#                              0						\
-#                              (* 300 (sin (* pi (/ i 25.0))))		\
-#                              (* 500 (sin (* pi (/ i 50.0))))))))	\
-#    (send *pr2* :inverse-kinematics p					\
-#          :look-at-target t						\
-#          :rotation-axis :z						\
-#          :use-base 0.1							\
-#          )								\
-#    (when (boundp '*irtviewer*)						\
-# 	(send *irtviewer* :objects (list *pr2* p))			\
-# 	(send *irtviewer* :draw-objects)				\
-# 	(x::window-main-one))						\
-#    (incf i)								\
-#    (when (> i 100) (exit 0))						\
-#    )									\
-#   (if (boundp '*irtviewer*) (send-all (send *pr2* :links) :draw-on :flush t))\
-#   (exit)                                                                \
-#   )									\
-# "
+rosrun roseus roseus lib/llib/unittest.l "(init-unit-test)" "\
+(progn									\
+  (load \"package://euscollada/pr2.l\")					\
+  (if (and x::*display* (> x::*display* 0) (not (boundp '*irtviewer*))) (make-irtviewer :title \"pr2.sh\"))			\
+  (if (not (boundp '*pr2*)) (pr2))					\
+									\
+  (send *pr2* :move-to (make-coords) :world)				\
+  (send *pr2* :reset-pose)						\
+  (when (boundp '*irtviewer*) (objects (list *pr2*)))			\
+  (setq i 0)								\
+  (do-until-key								\
+   (print (list i (send *pr2* :torso :waist-z :joint-angle)))		\
+   (setq p (make-coords :pos						\
+                        (v+ (float-vector 400 -400 1000)		\
+                            (float-vector				\
+                             0						\
+                             (* 100 (sin (* pi (/ i 25.0))))		\
+                             (* 200 (sin (* pi (/ i 50.0))))))))	\
+   (send *pr2* :rarm :inverse-kinematics p					\
+         :look-at-target t						\
+         :rotation-axis :z						\
+         )								\
+   (when (boundp '*irtviewer*)						\
+	(send *irtviewer* :objects (list *pr2* p))			\
+	(send *irtviewer* :draw-objects)				\
+	)						\
+   (incf i)								\
+   (when (> i 100) (exit 0))						\
+   )									\
+  (if (boundp '*irtviewer*) (send-all (send *pr2* :links) :draw-on :flush t))\
+  (exit)                                                                \
+  )									\
+"


### PR DESCRIPTION
Add dependency on pr2-common (pr2_mechanism_model) for euscollada conversion test.

After this commit, jsk_model_tools travis should be fail until Euslisp deb release.
This means jsk_model_tools's travis successfully trap Euslisp version violation.

Related PR or issues:
- Waiting for Euslisp deb release
  https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/35
- Moving code issue
  https://github.com/jsk-ros-pkg/jsk_model_tools/issues/41
