### PR TITLE
add *.yaml and *.sh to install

### DIFF
--- a/euscollada/catkin.cmake
+++ b/euscollada/catkin.cmake
@@ -33,3 +33,8 @@ install(TARGETS collada2eus collada2eus_urdfmodel
 install(DIRECTORY src
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   PATTERN ".svn" EXCLUDE)
+
+
+file(GLOB _install_files RELATIVE ${PROJECT_SOURCE_DIR} *.yaml *.sh)
+install(FILES ${_install_files}
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})


### PR DESCRIPTION
install *.sh and *.yaml, which is discussed in #49, but as I commented https://github.com/jsk-ros-pkg/jsk_model_tools/issues/49#issuecomment-46332931, pr2.yaml should put in pr2* package.
but since this blocks pr2eus travis test https://travis-ci.org/jsk-ros-pkg/jsk_pr2eus/jobs/27971640, i added this patch
