### PR TITLE
add code for viewing convex bodies

### DIFF
--- a/euscollada/src/euscollada-robot.l
+++ b/euscollada/src/euscollada-robot.l
@@ -27,6 +27,12 @@
      (send (send j :child-link) :add-parent-link (send j :parent-link))
      (send (send j :parent-link) :add-child-links (send j :child-link)))
    )
+  (:change-visual
+   (&optional (visual :convex))
+   (dolist (lk (send self :links))
+     (dolist (bd (send lk :bodies))
+       (when (derivedp bd collada-body)
+         (send bd :change-visual visual)))))
   ;; fullbody-inverse-kinematics overwrite
   ;;  reduce root-link's weight based on leg's joint limit
   ;;  increase stop and cog-gain
@@ -87,4 +93,26 @@
   (:set-color (&rest args)
    (send-super* :set-color args)
    (when glvertices (send* glvertices :set-color args)))
+  (:change-visual
+   (&optional (visual :convex))
+   (case visual
+     ((list :convex :hull :convex-hull)
+      (unless (send self :get :original-mesh)
+        (send self :put :original-mesh glvertices)) ;; store original mesh
+      (let* ((org-mesh (send self :get :original-mesh))
+             (org-cds (send org-mesh :copy-worldcoords))
+             (glv (gl::make-glvertices-from-faces (send self :faces))))
+        (send glv :set-offset (send org-cds :inverse-transformation))
+        (send glv :transform org-cds)
+        (send org-mesh :assoc glv)
+        (setq glvertices glv)
+        glv))
+     ((list :original :mesh :glvertices :original-mesh)
+      (let ((org-mesh (send self :get :original-mesh)))
+        (when org-mesh
+          (dolist (d (send org-mesh :descendants)) ;; dissoc all discendants
+            (send org-mesh :dissoc d))
+          (setq glvertices org-mesh)
+          org-mesh)))
+     ))
   )

--- a/euscollada/src/euscollada-robot_urdfmodel.l
+++ b/euscollada/src/euscollada-robot_urdfmodel.l
@@ -16,6 +16,12 @@
      (send (send j :child-link) :add-parent-link (send j :parent-link))
      (send (send j :parent-link) :add-child-links (send j :child-link)))
    )
+  (:change-visual
+   (&optional (visual :convex))
+   (dolist (lk (send self :links))
+     (dolist (bd (send lk :bodies))
+       (when (derivedp bd collada-body)
+         (send bd :change-visual visual)))))
   ;; fullbody-inverse-kinematics overwrite
   ;;  reduce root-link's weight based on leg's joint limit
   ;;  increase stop and cog-gain
@@ -66,6 +72,7 @@
 
 (defclass collada-body
 ;; This euscollada-body class is for bodies in robot model converted from collada files.
+;; Class definition is in euscollada/src/euscollada-robot.l
 ;; This class provides :draw override for displaying glvertices.
   :super body
   :slots (glvertices)
@@ -83,4 +90,26 @@
   (:set-color (&rest args)
    (send-super* :set-color args)
    (when glvertices (send* glvertices :set-color args)))
+  (:change-visual
+   (&optional (visual :convex))
+   (case visual
+     ((list :convex :hull :convex-hull)
+      (unless (send self :get :original-mesh)
+        (send self :put :original-mesh glvertices)) ;; store original mesh
+      (let* ((org-mesh (send self :get :original-mesh))
+             (org-cds (send org-mesh :copy-worldcoords))
+             (glv (gl::make-glvertices-from-faces (send self :faces))))
+        (send glv :set-offset (send org-cds :inverse-transformation))
+        (send glv :transform org-cds)
+        (send org-mesh :assoc glv)
+        (setq glvertices glv)
+        glv))
+     ((list :original :mesh :glvertices :original-mesh)
+      (let ((org-mesh (send self :get :original-mesh)))
+        (when org-mesh
+          (dolist (d (send org-mesh :descendants)) ;; dissoc all discendants
+            (send org-mesh :dissoc d))
+          (setq glvertices org-mesh)
+          org-mesh)))
+     ))
   )


### PR DESCRIPTION
You can confirm convex-hull of links by visualizing them.

```
send *robot* :change-visual :convex ;; change visual to convex-hull
send *robot* :change-visual :original ;; change visual to original meshes (default view)
```
