### PR TITLE
eus_assimp: build_depend on pkg-config

### DIFF
--- a/eus_assimp/package.xml
+++ b/eus_assimp/package.xml
@@ -15,6 +15,7 @@
 
   <build_depend>euslisp</build_depend>
   <build_depend>assimp_devel</build_depend>
+  <build_depend>pkg-config</build_depend>
 
   <run_depend>roseus</run_depend>
   <run_depend>assimp_devel</run_depend>


### PR DESCRIPTION
Example Ubuntu break: http://jenkins.ros.org/job/ros-indigo-eus-assimp_binarydeb_saucy_amd64/14/consoleFull