### PR TITLE
[euscollada] return if limb key not found

### DIFF
--- a/euscollada/scripts/parseColladaBase.py
+++ b/euscollada/scripts/parseColladaBase.py
@@ -428,6 +428,9 @@ class yamlParser:
                 parent  = eff['parent'] if 'parent' in eff else None
                 root  = eff['root'] if 'root' in eff else 'BODY'
                 if not parent:
+                    if not self.yaml_data.has_key(limb):
+                        print >>sys.stderr, "cannot find limb: %s" %(limb)
+                        return
                     limb_lst = self.yaml_data[limb]
                     parent = limb_lst[-1].keys()[0].replace("JOINT", "LINK") # not goood!
                 xml_obj.add_manipulator('%s_end_coords'%limb, root, parent,


### PR DESCRIPTION
@garaemon さん

SampleRobotは
head-end-coordsを持っていますが，headに属する関節がないため，
add_sensor_to_collada.pyで以下のエラーが起きて，
このPRで直りました．

問題なさそうか確認お願いします．

```
[hrpsys_ros_bridge_tutorials] Traceback (most recent call last):
[hrpsys_ros_bridge_tutorials]   File "/home/leus/ros/hydro/src/jsk-ros-pkg/jsk_model_tools/euscollada/scripts/add_sensor_to_collada.py", line 45, in <module>
[hrpsys_ros_bridge_tutorials]     yaml_obj.replace_xmls(obj)
[hrpsys_ros_bridge_tutorials]   File "/home/leus/ros/hydro/src/jsk-ros-pkg/jsk_model_tools/euscollada/scripts/parseColladaBase.py", line 476, in replace_xmls
[hrpsys_ros_bridge_tutorials]     raise Exception("yaml does not have tag section")
[hrpsys_ros_bridge_tutorials] Exception: yaml does not have tag section
[hrpsys_ros_bridge_tutorials] make[2]: *** [/home/leus/ros/hydro/src/rtm-ros-robotics/rtmros_tutorials/hrpsys_ros_bridge_tutorials/models/SampleRobot_WH_SENSORS.urdf]  1
[hrpsys_ros_bridge_tutorials] make[1]: *** [CMakeFiles/urdf_generated_9.dir/all]  2
[hrpsys_ros_bridge_tutorials] <== '/home/leus/ros/hydro/build/hrpsys_ros_bridge_tutorials/build_env.sh /usr/bin/make --jobserver-fds=3,5 -j' failed with return code '2'
Failed   <== hrpsys_ros_bridge_tutorials [ 5.1 seconds ]
[build] There were '1' errors:
```
