### PR TITLE
Fix large matrix

### DIFF
--- a/euscollada/src/collada2eus.cpp
+++ b/euscollada/src/collada2eus.cpp
@@ -201,21 +201,21 @@ void writeTriangle(FILE *fp, domGeometry *thisGeometry, const char* robot_name) 
       if (verbose) {
         fprintf(stderr, "numberOfVertices = %d\n", numberOfVertices);
       }
-      fprintf(fp, "           (list :vertices #2f(");
+      fprintf(fp, "            (list :vertices (let ((mat (make-matrix %d 3))) (fvector-replace (array-entity mat) #f(", numberOfVertices / 3);
       for(int i = 0; i < numberOfVertices / 3; i++) {
         // vertex vector
         float a0, a1, a2;
         a0 = thisMesh->getSource_array()[currentSource]->getFloat_array()->getValue().get(i * 3);
         a1 = thisMesh->getSource_array()[currentSource]->getFloat_array()->getValue().get(i * 3 + 1);
         a2 = thisMesh->getSource_array()[currentSource]->getFloat_array()->getValue().get(i * 3 + 2);
-        fprintf(fp, "("FLOAT_PRECISION_FINE" "FLOAT_PRECISION_FINE" "FLOAT_PRECISION_FINE")",
+        fprintf(fp, FLOAT_PRECISION_FINE" "FLOAT_PRECISION_FINE" "FLOAT_PRECISION_FINE" ",
                 g_scale * 1000 * a0, g_scale * 1000 * a1, g_scale * 1000 * a2);
         // store vertex vector to qhull
         points.push_back(a0);
         points.push_back(a1);
         points.push_back(a2);
       }
-      fprintf(fp, "))\n"); // /vertices
+      fprintf(fp, ")) mat))\n"); // /vertices
       currentSource++;
       sourceElements--;
     }
@@ -224,21 +224,21 @@ void writeTriangle(FILE *fp, domGeometry *thisGeometry, const char* robot_name) 
     if (sourceElements != 0) {
       if(noroffset == -255) {
         if(!!(thisMesh->getSource_array()[currentSource]->getFloat_array())) {
-          // normal vector shares same index of vertices
-          fprintf(fp, "         (list :normals #2f(");
           int numberOfNormals = thisMesh->getSource_array()[currentSource]->getFloat_array()->getValue().getCount();
+          // normal vector shares same index of vertices
+          fprintf(fp, "          (list :normals (let ((mat (make-matrix %d 3))) (fvector-replace (array-entity mat) #f(", numberOfNormals);
           if (verbose) {
             fprintf(stderr, "A:numberOfNormals = %d\n", numberOfNormals);
           }
           for (int i = 0; i < numberOfNormals; i++) {
             if (verbose) {
-              fprintf(stderr, "(%f %f %f)",
+              fprintf(stderr, FLOAT_PRECISION_FINE" "FLOAT_PRECISION_FINE" "FLOAT_PRECISION_FINE" ",
                       thisMesh->getSource_array()[currentSource]->getFloat_array()->getValue().get(i * 3),
                       thisMesh->getSource_array()[currentSource]->getFloat_array()->getValue().get(i * 3 + 1),
                       thisMesh->getSource_array()[currentSource]->getFloat_array()->getValue().get(i * 3 + 2));
             }
           }
-          fprintf(fp, "))\n");  // /normals
+          fprintf(fp, ")) mat))\n");  // /normals
           currentSource++;
           sourceElements--;
         } else {


### PR DESCRIPTION
https://github.com/euslisp/EusLisp/pull/139 にも関係するんですが、
verticesをN行３列 行列にしているんですが、Nが大きくなるとロード時間が
Nx3要素のfloat-vectorに比べて大幅に時間がかかることがわかりました。
なのでベクトルを読んでから行列に入れています。
これでjaxon_redのロード時間が半分くらいになります。