### PR TITLE
[euscollada] Add :user-defined-joints method to get list of user-defined joint methods

### DIFF
--- a/euscollada/src/collada2eus.cpp
+++ b/euscollada/src/collada2eus.cpp
@@ -1669,6 +1669,16 @@ int main(int argc, char* argv[]){
       fprintf(output_fp, "    (:%s (&rest args) (forward-message-to %s args))\n", it->second.c_str(), it->first.c_str());
     }
   }
+  fprintf(output_fp, "    (:user-defined-joints ()\n");
+  fprintf(output_fp, "       (list\n");
+  for(vector<pair<string, string> >::iterator it=g_all_link_names.begin();it!=g_all_link_names.end();it++){
+    if(add_joint_suffix) {
+      fprintf(output_fp, "          (cons :%s %s_jt)\n", it->second.c_str(), it->first.c_str());
+    } else {
+      fprintf(output_fp, "          (cons :%s %s)\n", it->second.c_str(), it->first.c_str());
+    }
+  }
+  fprintf(output_fp, "       ))\n");
   // sensor
   fprintf(output_fp, "\n    ;; attach_sensor\n");
   if ( g_dae->getDatabase()->getElementCount(NULL, "articulated_system", NULL) > 0 ) {


### PR DESCRIPTION
It will generates method like
```lisp
    (:user-defined-joints ()
       (list
          (cons :rleg-crotch-y RLEG_JOINT0_jt)
          (cons :rleg-crotch-r RLEG_JOINT1_jt)
          (cons :rleg-crotch-p RLEG_JOINT2_jt)
          (cons :rleg-knee-p RLEG_JOINT3_jt)
          (cons :rleg-ankle-p RLEG_JOINT4_jt)
          (cons :rleg-ankle-r RLEG_JOINT5_jt)
          (cons :rleg-toe-p RLEG_JOINT6_jt)
          (cons :lleg-crotch-y LLEG_JOINT0_jt)
          (cons :lleg-crotch-r LLEG_JOINT1_jt)
          (cons :lleg-crotch-p LLEG_JOINT2_jt)
          (cons :lleg-knee-p LLEG_JOINT3_jt)
          (cons :lleg-ankle-p LLEG_JOINT4_jt)
          (cons :lleg-ankle-r LLEG_JOINT5_jt)
          (cons :lleg-toe-p LLEG_JOINT6_jt)
          (cons :torso-waist-y CHEST_JOINT0_jt)
          (cons :torso-waist-p CHEST_JOINT1_jt)
          (cons :head-neck-y HEAD_JOINT0_jt)
          (cons :head-neck-p HEAD_JOINT1_jt)
          (cons :rarm-shoulder-p RARM_JOINT0_jt)
          (cons :rarm-shoulder-r RARM_JOINT1_jt)
          (cons :rarm-shoulder-y RARM_JOINT2_jt)
          (cons :rarm-elbow-p RARM_JOINT3_jt)
          (cons :rarm-wrist-y RARM_JOINT4_jt)
          (cons :rarm-wrist-r RARM_JOINT5_jt)
          (cons :rarm-wrist-p RARM_JOINT6_jt)
          (cons :rarm-thumb-r RARM_JOINT7_jt)
          (cons :larm-shoulder-p LARM_JOINT0_jt)
          (cons :larm-shoulder-r LARM_JOINT1_jt)
          (cons :larm-shoulder-y LARM_JOINT2_jt)
          (cons :larm-elbow-p LARM_JOINT3_jt)
          (cons :larm-wrist-y LARM_JOINT4_jt)
          (cons :larm-wrist-r LARM_JOINT5_jt)
          (cons :larm-wrist-p LARM_JOINT6_jt)
          (cons :larm-thumb-r LARM_JOINT7_jt)
       ))
```