### PR TITLE
[eusurdf] generate urdf.xacro for model / scene

### DIFF
--- a/eusurdf/.gitignore
+++ b/eusurdf/.gitignore
@@ -1,2 +1,3 @@
 models
 worlds
+launch

--- a/eusurdf/CMakeLists.txt
+++ b/eusurdf/CMakeLists.txt
@@ -9,8 +9,9 @@ catkin_package()
 include(cmake/eusurdf.cmake)
 convert_eusmodel_to_urdf()
 convert_eusscene_to_gazebo_world()
+convert_eusscene_to_urdf_xacro()
 
-install(DIRECTORY models worlds
+install(DIRECTORY models textured_models worlds launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS)
 

--- a/eusurdf/README.md
+++ b/eusurdf/README.md
@@ -20,3 +20,25 @@ roseus convert-eus-to-urdf.l
 ;; util wrapper function to convert room model
 (generate-room-models "room73b2")
 ```
+
+## Spawn scene model to gazebo
+
+- Use world file
+
+``` bash
+roslaunch gazebo_ros empty_world.launch world_name:=`rospack find eusurdf`/worlds/room73b2.world
+```
+
+- Use urdf.xacro file
+
+``` bash
+roslaunch gazebo_ros empty_world.launch
+roslaunch eusurdf gazebo_spawn_room73b2.launch
+```
+
+## Apply changes of URDF in textured_models to urdf.xacro
+
+``` bash
+roscd eusurdf && ./textured_models/apply_to_xacro.sh
+```
+

--- a/eusurdf/euslisp/eusscene_to_xacro.l
+++ b/eusurdf/euslisp/eusscene_to_xacro.l
@@ -1,0 +1,117 @@
+;; eusscene_to_xacro.l
+;; Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+
+;; assumed executed at PROJECT_SOURCE_DIR
+(defparameter *eusurdf-package-path* (unix:getwd))
+(require :conversion-utils (format nil "~A/euslisp/conversion-utils.l" *eusurdf-package-path*))
+
+(defun write-spawn-launch-file (s scene-name xacro-path)
+  (format s "<launch>~%")
+  (format s "  <!-- spawn ~A to gazebo -->~%" xacro-path)
+  (format s "  <arg name=\"model\" default=\"~A\"/>~%" xacro-path)
+  (format s "  <param name=\"~A_description\" command=\"$(find xacro)/xacro.py '$(arg model)'\"/>~%" scene-name)
+  (format s "  <node name=\"spawn_~A\" pkg=\"gazebo_ros\" type=\"spawn_model\"~%" scene-name)
+  (format s "        args=\"-param ~A_description -urdf -model ~A\"/>~%" scene-name scene-name)
+  (format s "</launch>~%"))
+
+(defun write-xacro-file-header (s name root-link-name)
+  (format s "<?xml version=\"1.0\" ?>~%~%")
+  (format s "<robot name=\"~A\" xmlns:xacro=\"http://ros.org/wiki/xacro\">~%~%" name)
+  (format s "  <macro name=\"sphere_inertia\" params=\"radius mass\">~%")
+  (format s "    <inertial>~%")
+  (format s "      <origin xyz=\"0.0 0.0 0.0\" rpy=\"0 0 0\"/>~%")
+  (format s "      <mass value=\"1\" />~%")
+  (format s "      <inertia ixx=\"1\" ixy=\"0.0\" ixz=\"0.0\" iyy=\"1\" iyz=\"0.0\" izz=\"1\"/>~%")
+  (format s "    </inertial>~%")
+  (format s "  </macro>~%")
+  (format s "  <link name=\"~A\">~%" root-link-name)
+  (format s "    <sphere_inertia radius=\"0\" mass=\"0\"/>~%")
+  (format s "  </link>~%")
+  (format s "  <gazebo>~%")
+  (format s "    <static>false</static>~%")
+  (format s "  </gazebo>~%")
+)
+
+(defun write-xacro-file-footer (s)
+  (format s "</robot>~%"))
+
+(defun write-model-include-xml-stirng (s model model-name-suffix xacro-path parent-link &optional model-name (indent 2))
+  (unless model-name (setq model-name (send model :name)))
+  (let ((pos-string (string-join " " (coerce (scale 0.001 (send model :worldpos)) cons)))
+        (rpy-string (string-join " " (reverse (coerce (car (rpy-angle (send model :worldrot))) cons))))
+        (indent-string (make-indent-string indent)))
+    (format s "~A<xacro:include filename=\"~A\"/>~%" indent-string xacro-path)
+    (format s "~A<~A~A name=\"~A\" parent=\"~A\">~%" indent-string
+            (send model :name) model-name-suffix model-name parent-link)
+    (format s "~A  <origin xyz=\"~A\" rpy=\"~A\"/>~%" indent-string pos-string rpy-string)
+    (format s "~A</~A~A>~%" indent-string (send model :name) model-name-suffix)))
+
+(defun eusscene2xacro (scene-file-name xacro-file-name launch-file-name)
+  (unless (probe-file scene-file-name)
+    (errorf "file ~A not exists" scene-file-name))
+  (load scene-file-name)
+  (let* ((scene-name (string-join "-"
+                                  (butlast
+                                   (string-split (send (pathname scene-file-name) :name) #\-))))
+         (scene (funcall (read-from-string scene-name)))
+         (root-link-name (format nil "~A_root_link" scene-name))
+         (model-count (make-hash-table)))
+    (make-dirs (send (pathname xacro-file-name) :directory-string))
+    (with-open-file (f xacro-file-name :direction :output :if-exists :overwrite)
+      (write-xacro-file-header f scene-name root-link-name)
+      (dolist (model (remove-if-not #'(lambda (x)
+                                        (and (subclassp (class x) cascaded-link)
+                                             (not (null (send x :links)))))
+                                    (send scene :objects)))
+        ;; stringify model name
+        (cond ((null (send model :name)) (send model :name "no-name"))
+              ((symbolp (send model :name)) (send model :name (string-downcase (send model :name)))))
+
+        ;; include model xacro file
+        (let ((model-name-key (read-from-string (send model :name)))
+              (model-name-suffix "")
+              model-name xacro-path)
+          (if (gethash model-name-key model-count)
+              (incf (gethash model-name-key model-count))
+              (setf (gethash model-name-key model-count) 0))
+          (setq model-name (string-join "_"
+                                        (list
+                                         (send model :name)
+                                         (gethash model-name-key model-count))))
+          (case (use-textured-model-p (send model :name))
+            (:fixed
+             (setq model-name-suffix "_fixed")
+             (setq xacro-path
+                   (format nil "$(find eusurdf)/textured_models/~A_fixed/model.urdf.xacro" (send model :name))))
+            (:static
+             (setq model-name-suffix "_static")
+             (setq xacro-path
+                   (format nil "$(find eusurdf)/textured_models/~A_static/model.urdf.xacro" (send model :name))))
+            (nil
+             (setq xacro-path
+                   (format nil "$(find eusurdf)/models/~A/model.urdf.xacro" (send model :name))))
+            (t
+             (setq xacro-path
+                   (format nil "$(find eusurdf)/textured_models/~A/model.urdf.xacro" (send model :name)))))
+          (write-model-include-xml-stirng f model model-name-suffix xacro-path root-link-name model-name)))
+      (write-xacro-file-footer f))
+
+    ;; make spawn launch file
+    (make-dirs (send (pathname launch-file-name) :directory-string))
+    (let ((short-xacro-file-name (copy-seq xacro-file-name)))
+      (when (substringp *eusurdf-package-path* short-xacro-file-name)
+        (setq short-xacro-file-name
+              (format nil "$(find eusurdf)/~A"
+                      (subseq short-xacro-file-name
+                              (1+ (length *eusurdf-package-path*))
+                              (length short-xacro-file-name)))))
+      (with-open-file (f launch-file-name :direction :output :if-exists :overwrite)
+        (write-spawn-launch-file f scene-name short-xacro-file-name)))
+    ))
+
+(setq scene-file-path (car (last (butlast (butlast lisp::*eustop-argument*)))))
+(setq xacro-file-path (car (last (butlast lisp::*eustop-argument*))))
+(setq launch-file-path (car (last lisp::*eustop-argument*)))
+(format t "converting eus scene ~A -> ~A, ~A~%" scene-file-path xacro-file-path launch-file-path)
+(eusscene2xacro scene-file-path xacro-file-path launch-file-path)
+(exit)

--- a/eusurdf/package.xml
+++ b/eusurdf/package.xml
@@ -23,6 +23,7 @@
 
   <run_depend>collada_urdf_jsk_patch</run_depend>
   <run_depend>gazebo_ros</run_depend>
+  <run_depend>python-lxml</run_depend>
   <run_depend>rostest</run_depend>
 
   <export>

--- a/eusurdf/scripts/urdf_to_xacro.py
+++ b/eusurdf/scripts/urdf_to_xacro.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+
+
+import lxml.etree
+import lxml.builder
+import os
+import sys
+
+class InvalidURDFException(Exception):
+    pass
+
+
+class URDF2XACRO(object):
+    def __init__(self, urdf_path, xacro_path):
+        self.root = lxml.etree.parse(urdf_path,
+                                     parser=lxml.etree.XMLParser(remove_blank_text=True))
+        self.xacro_path = xacro_path
+    def find_root_link(self):
+        links = self.root.xpath("//robot/link")
+        if len(links) == 0:
+            raise InvalidURDFException("No link found in model")
+        elif len(links) == 1:
+            return links[0]
+        else:
+            link_names = [l.get("name") for l in links]
+            joints = self.root.xpath("//robot/joint")
+            for j in joints:
+                child_link_name = j.find("child").get("link")
+                if child_link_name in link_names:
+                    link_names.remove(child_link_name)
+            if len(link_names) != 1:
+                raise InvalidURDFException("Links are not connected with joints: %s" % link_names)
+            return self.root.xpath("//robot/link[@name='%s']" % link_names[0])[0]
+    def add_namespace(self, ns):
+        ns_str = "${%s}_" % ns
+
+        links = self.root.xpath("//robot/link")
+        for l in links:
+            l.set("name", ns_str + l.get("name"))
+
+        gazebo = self.root.xpath("//robot/gazebo")
+        for g in gazebo:
+            if g.get("reference") is not None:
+                g.set("reference", ns_str + g.get("reference"))
+
+        joints = self.root.xpath("//robot/joint")
+        for j in joints:
+            j.set("name", ns_str + j.get("name"))
+            j_parent = j.find("parent")
+            j_parent.set("link", ns_str +  j_parent.get("link"))
+            j_child = j.find("child")
+            j_child.set("link", ns_str + j_child.get("link"))
+
+        transmissions = self.root.xpath("//robot/transmission")
+        for t in transmissions:
+            t.set("name", ns_str + t.get("name"))
+            t_joint = t.find("joint")
+            t_joint.set("name", ns_str + t_joint.get("name"))
+            t_actuator = t.find("actuator")
+            t_actuator.set("name", ns_str + t_actuator.get("name"))
+
+    def inject_macro(self):
+        self.add_namespace("name")
+        root_link = self.find_root_link()
+        robot = self.root.getroot()
+        robot_name = robot.get("name")
+        first_joint = robot.find("joint")
+        virtual_joint = lxml.etree.Element("joint",
+                                           attrib={"name": "${name}_root_parent_joint", "type": "fixed"})
+        virtual_joint.append(lxml.etree.Element("parent", attrib={"link": "${parent}"}))
+        virtual_joint.append(lxml.etree.Element("child", attrib={"link": root_link.get("name")}))
+        virtual_joint.append(lxml.etree.Element("insert_block", attrib={"name": "origin"}))
+        if first_joint is not None:
+            first_joint.addprevious(virtual_joint)
+        else:
+            robot.append(virtual_joint)
+        macro = lxml.etree.Element("macro",
+                                   attrib={"name": robot_name, "params": "name parent *origin"})
+        for e in robot.getchildren():
+            macro.append(e)
+        for e in robot.getchildren():
+            robot.remove(e)
+        robot.append(macro)
+
+    def save(self):
+        out_path = os.path.abspath(self.xacro_path)
+        if not os.path.exists(os.path.dirname(out_path)):
+            os.makedirs(os.path.dirname(out_path))
+        xmlstring = lxml.etree.tostring(self.root,
+                                        encoding="utf-8",
+                                        xml_declaration=True,
+                                        pretty_print=True,
+                                        with_comments=True)
+        with open(out_path, "w") as f:
+            f.write(xmlstring)
+        print "saved to %s" % out_path
+    def convert(self):
+        self.inject_macro()
+        self.save()
+
+if __name__ == '__main__':
+    import argparse
+    p = argparse.ArgumentParser(description="xacrify urdf file")
+    p.add_argument("urdf", type=str, help="path to input urdf file")
+    p.add_argument("xacro", type=str, help="path to output xacro file")
+    args = p.parse_args()
+
+    c = URDF2XACRO(args.urdf, args.xacro)
+    c.convert()

--- a/eusurdf/textured_models/apply_to_xacro.sh
+++ b/eusurdf/textured_models/apply_to_xacro.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+for d in `find $DIR  -maxdepth 1 -mindepth 1 -type d`; do
+  rosrun eusurdf urdf_to_xacro.py $d/model.urdf $d/model.urdf.xacro
+done

--- a/eusurdf/textured_models/room73b2-georgia-emerald-mountain/model.urdf.xacro
+++ b/eusurdf/textured_models/room73b2-georgia-emerald-mountain/model.urdf.xacro
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot xmlns:xi="http://www.w3.org/2001/XInclude" name="room73b2-georgia-emerald-mountain">
+  <macro name="room73b2-georgia-emerald-mountain" params="name parent *origin">
+    <gazebo>
+      <static>false</static>
+    </gazebo>
+    <link name="${name}_nil_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-georgia-emerald-mountain/meshes/nil_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-georgia-emerald-mountain/meshes/nil_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.3"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_nil_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <joint name="${name}_root_parent_joint" type="fixed">
+      <parent link="${parent}"/>
+      <child link="${name}_nil_link"/>
+      <insert_block name="origin"/>
+    </joint>
+  </macro>
+</robot>

--- a/eusurdf/textured_models/room73b2-hitachi-fiesta-refrigerator/model.urdf.xacro
+++ b/eusurdf/textured_models/room73b2-hitachi-fiesta-refrigerator/model.urdf.xacro
@@ -1,0 +1,270 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot xmlns:xi="http://www.w3.org/2001/XInclude" name="room73b2-hitachi-fiesta-refrigerator">
+  <macro name="room73b2-hitachi-fiesta-refrigerator" params="name parent *origin">
+    <gazebo>
+      <static>false</static>
+    </gazebo>
+    <link name="${name}_ROOT_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOT_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOT_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="50.0"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOT_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link">
+      <visual>
+        <origin xyz="0.3 0.245 0.85" rpy="-1.57 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0.3 0.245 0.85" rpy="-1.57 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="2.0"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link">
+      <visual>
+        <origin xyz="0.05 0 0.66" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0.05 0 0.66" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="1.0"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link">
+      <visual>
+        <origin xyz="0.06 0 0.24" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0.06 0 0.24" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="1.0"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link">
+      <visual>
+        <origin xyz="-0.095 0 1.275" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="-0.095 0 1.275" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="1.0"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link">
+      <visual>
+        <origin xyz="-0.095 0 1.085" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="-0.095 0 1.085" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="1.0"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link">
+      <visual>
+        <origin xyz="-0.095 0 0.935" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="-0.095 0 0.935" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="1.0"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1" ixy="0" ixz="0" iyy="1" iyz="0" izz="1"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <joint name="${name}_root_parent_joint" type="fixed">
+      <parent link="${parent}"/>
+      <child link="${name}_ROOT_link"/>
+      <insert_block name="origin"/>
+    </joint>
+    <joint name="${name}_DOOR1" type="revolute">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link"/>
+      <origin xyz="0.3 0.245 0.85" rpy="0 -0 0 "/>
+      <axis xyz="0 0 1"/>
+      <limit lower="0" upper="2.0944" effort="100" velocity="0.5"/>
+      <dynamics damping="1" friction="0.1"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_DOOR1_trans">
+      <actuator name="${name}_DOOR1_motor"/>
+      <joint name="${name}_DOOR1"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_DOOR1">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_DRAWER1" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link"/>
+      <origin xyz="0.05 0 0.66" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.55" effort="100" velocity="0.01"/>
+      <dynamics damping="1000" friction="10."/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_DRAWER1_trans">
+      <actuator name="${name}_DRAWER1_motor"/>
+      <joint name="${name}_DRAWER1"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_DRAWER1">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_DRAWER2" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link"/>
+      <origin xyz="0.06 0 0.24" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.55" effort="100" velocity="0.01"/>
+      <dynamics damping="1000" friction="10."/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_DRAWER2_trans">
+      <actuator name="${name}_DRAWER2_motor"/>
+      <joint name="${name}_DRAWER2"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_DRAWER2">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_SHELF1" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link"/>
+      <origin xyz="-0.095 0 1.275" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.3" effort="100" velocity="0.01"/>
+      <dynamics damping="1000" friction="10."/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_SHELF1_trans">
+      <actuator name="${name}_SHELF1_motor"/>
+      <joint name="${name}_SHELF1"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_SHELF1">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_SHELF2" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link"/>
+      <origin xyz="-0.095 0 1.085" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.3" effort="100" velocity="0.01"/>
+      <dynamics damping="1000" friction="10."/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_SHELF2_trans">
+      <actuator name="${name}_SHELF2_motor"/>
+      <joint name="${name}_SHELF2"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_SHELF2">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_SHELF3" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link"/>
+      <origin xyz="-0.095 0 0.935" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.3" effort="100" velocity="0.01"/>
+      <dynamics damping="1000" friction="10."/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_SHELF3_trans">
+      <actuator name="${name}_SHELF3_motor"/>
+      <joint name="${name}_SHELF3"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_SHELF3">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+  </macro>
+</robot>

--- a/eusurdf/textured_models/room73b2-hitachi-fiesta-refrigerator_fixed/model.urdf.xacro
+++ b/eusurdf/textured_models/room73b2-hitachi-fiesta-refrigerator_fixed/model.urdf.xacro
@@ -1,0 +1,276 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot xmlns:xi="http://www.w3.org/2001/XInclude" name="room73b2-hitachi-fiesta-refrigerator_fixed">
+  <macro name="room73b2-hitachi-fiesta-refrigerator_fixed" params="name parent *origin">
+    <gazebo>
+      <static>false</static>
+    </gazebo>
+    <link name="${name}_ROOT_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOT_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOT_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOT_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link">
+      <visual>
+        <origin xyz="0.3 0.25 0.85" rpy="-1.57 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0.3 0.245 0.85" rpy="-1.57 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link">
+      <visual>
+        <origin xyz="0.05 0 0.66" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0.05 0 0.66" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link">
+      <visual>
+        <origin xyz="0.06 0 0.24" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0.06 0 0.24" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link">
+      <visual>
+        <origin xyz="-0.095 0 1.275" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="-0.095 0 1.275" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link">
+      <visual>
+        <origin xyz="-0.095 0 1.085" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="-0.095 0 1.085" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link">
+      <visual>
+        <origin xyz="-0.095 0 0.935" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="-0.095 0 0.935" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <joint name="${name}_root_parent_joint" type="fixed">
+      <parent link="${parent}"/>
+      <child link="${name}_world"/>
+      <insert_block name="origin"/>
+    </joint>
+    <joint name="${name}_DOOR1" type="revolute">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link"/>
+      <origin xyz="0.3 0.245 0.85" rpy="0 -0 0 "/>
+      <axis xyz="0 0 1"/>
+      <limit lower="0" upper="1.5708" effort="100" velocity="0.5"/>
+      <dynamics damping="0.2" friction="0"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_DOOR1_trans">
+      <actuator name="${name}_DOOR1_motor"/>
+      <joint name="${name}_DOOR1"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_DOOR1">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_DRAWER1" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link"/>
+      <origin xyz="0.05 0 0.66" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.55" effort="100" velocity="0.01"/>
+      <dynamics damping="0.2" friction="0"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_DRAWER1_trans">
+      <actuator name="${name}_DRAWER1_motor"/>
+      <joint name="${name}_DRAWER1"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_DRAWER1">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_DRAWER2" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link"/>
+      <origin xyz="0.06 0 0.24" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.55" effort="100" velocity="0.01"/>
+      <dynamics damping="0.2" friction="0"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_DRAWER2_trans">
+      <actuator name="${name}_DRAWER2_motor"/>
+      <joint name="${name}_DRAWER2"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_DRAWER2">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_SHELF1" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link"/>
+      <origin xyz="-0.095 0 1.275" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.3" effort="100" velocity="0.01"/>
+      <dynamics damping="0.2" friction="0"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_SHELF1_trans">
+      <actuator name="${name}_SHELF1_motor"/>
+      <joint name="${name}_SHELF1"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_SHELF1">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_SHELF2" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link"/>
+      <origin xyz="-0.095 0 1.085" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.3" effort="100" velocity="0.01"/>
+      <dynamics damping="0.2" friction="0"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_SHELF2_trans">
+      <actuator name="${name}_SHELF2_motor"/>
+      <joint name="${name}_SHELF2"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_SHELF2">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_SHELF3" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link"/>
+      <origin xyz="-0.095 0 0.935" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.3" effort="100" velocity="0.01"/>
+      <dynamics damping="0.2" friction="0"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_SHELF3_trans">
+      <actuator name="${name}_SHELF3_motor"/>
+      <joint name="${name}_SHELF3"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_SHELF3">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <!-- Used for fixing robot to Gazebo 'base_link' -->
+    <link name="${name}_world"/>
+    <joint name="${name}_fixed" type="fixed">
+      <parent link="${name}_world"/>
+      <child link="${name}_ROOT_link"/>
+    </joint>
+  </macro>
+</robot>

--- a/eusurdf/textured_models/room73b2-hitachi-fiesta-refrigerator_static/model.urdf.xacro
+++ b/eusurdf/textured_models/room73b2-hitachi-fiesta-refrigerator_static/model.urdf.xacro
@@ -1,0 +1,270 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot xmlns:xi="http://www.w3.org/2001/XInclude" name="room73b2-hitachi-fiesta-refrigerator_static">
+  <macro name="room73b2-hitachi-fiesta-refrigerator_static" params="name parent *origin">
+    <gazebo>
+      <static>true</static>
+    </gazebo>
+    <link name="${name}_ROOT_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOT_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOT_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOT_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link">
+      <visual>
+        <origin xyz="0.3 0.245 0.85" rpy="-1.57 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0.3 0.245 0.85" rpy="-1.57 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link">
+      <visual>
+        <origin xyz="0.05 0 0.66" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0.05 0 0.66" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link">
+      <visual>
+        <origin xyz="0.06 0 0.24" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0.06 0 0.24" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link">
+      <visual>
+        <origin xyz="-0.095 0 1.275" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="-0.095 0 1.275" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link">
+      <visual>
+        <origin xyz="-0.095 0 1.085" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="-0.095 0 1.085" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <link name="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link">
+      <visual>
+        <origin xyz="-0.095 0 0.935" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="-0.095 0 0.935" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-hitachi-fiesta-refrigerator/meshes/ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.001"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <joint name="${name}_root_parent_joint" type="fixed">
+      <parent link="${parent}"/>
+      <child link="${name}_ROOT_link"/>
+      <insert_block name="origin"/>
+    </joint>
+    <joint name="${name}_DOOR1" type="revolute">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET7_link"/>
+      <origin xyz="0.3 0.245 0.85" rpy="0 -0 0 "/>
+      <axis xyz="0 0 1"/>
+      <limit lower="0" upper="1.5708" effort="100" velocity="0.5"/>
+      <dynamics damping="0.2" friction="0"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_DOOR1_trans">
+      <actuator name="${name}_DOOR1_motor"/>
+      <joint name="${name}_DOOR1"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_DOOR1">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_DRAWER1" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET6_link"/>
+      <origin xyz="0.05 0 0.66" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.55" effort="100" velocity="0.01"/>
+      <dynamics damping="0.2" friction="0"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_DRAWER1_trans">
+      <actuator name="${name}_DRAWER1_motor"/>
+      <joint name="${name}_DRAWER1"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_DRAWER1">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_DRAWER2" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET5_link"/>
+      <origin xyz="0.06 0 0.24" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.55" effort="100" velocity="0.01"/>
+      <dynamics damping="0.2" friction="0"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_DRAWER2_trans">
+      <actuator name="${name}_DRAWER2_motor"/>
+      <joint name="${name}_DRAWER2"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_DRAWER2">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_SHELF1" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET4_link"/>
+      <origin xyz="-0.095 0 1.275" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.3" effort="100" velocity="0.01"/>
+      <dynamics damping="0.2" friction="0"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_SHELF1_trans">
+      <actuator name="${name}_SHELF1_motor"/>
+      <joint name="${name}_SHELF1"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_SHELF1">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_SHELF2" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET3_link"/>
+      <origin xyz="-0.095 0 1.085" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.3" effort="100" velocity="0.01"/>
+      <dynamics damping="0.2" friction="0"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_SHELF2_trans">
+      <actuator name="${name}_SHELF2_motor"/>
+      <joint name="${name}_SHELF2"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_SHELF2">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+    <joint name="${name}_SHELF3" type="prismatic">
+      <parent link="${name}_ROOT_link"/>
+      <child link="${name}_ROOM73B2-HITACHI-FIESTA-REFRIGERATOR-BODYSET2_link"/>
+      <origin xyz="-0.095 0 0.935" rpy="0 -0 0 "/>
+      <axis xyz="1 0 0"/>
+      <limit lower="0" upper="0.3" effort="100" velocity="0.01"/>
+      <dynamics damping="0.2" friction="0"/>
+    </joint>
+    <transmission type="pr2_mechanism_model/SimpleTransmission" name="${name}_SHELF3_trans">
+      <actuator name="${name}_SHELF3_motor"/>
+      <joint name="${name}_SHELF3"/>
+      <mechanicalReduction>1</mechanicalReduction>
+    </transmission>
+    <gazebo reference="${name}_SHELF3">
+      <cfmDamping>0.4</cfmDamping>
+    </gazebo>
+  </macro>
+</robot>

--- a/eusurdf/textured_models/room73b2-iemon/model.urdf.xacro
+++ b/eusurdf/textured_models/room73b2-iemon/model.urdf.xacro
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot xmlns:xi="http://www.w3.org/2001/XInclude" name="room73b2-iemon">
+  <macro name="room73b2-iemon" params="name parent *origin">
+    <gazebo>
+      <static>false</static>
+    </gazebo>
+    <link name="${name}_nil_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-iemon/meshes/nil_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-iemon/meshes/nil_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.3"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_nil_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <joint name="${name}_root_parent_joint" type="fixed">
+      <parent link="${parent}"/>
+      <child link="${name}_nil_link"/>
+      <insert_block name="origin"/>
+    </joint>
+  </macro>
+</robot>

--- a/eusurdf/textured_models/room73b2-mac-burger-box/model.urdf.xacro
+++ b/eusurdf/textured_models/room73b2-mac-burger-box/model.urdf.xacro
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot xmlns:xi="http://www.w3.org/2001/XInclude" name="room73b2-mac-burger-box">
+  <macro name="room73b2-mac-burger-box" params="name parent *origin">
+    <gazebo>
+      <static>false</static>
+    </gazebo>
+    <link name="${name}_nil_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-mac-burger-box/meshes/nil_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-mac-burger-box/meshes/nil_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.3"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_nil_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <joint name="${name}_root_parent_joint" type="fixed">
+      <parent link="${parent}"/>
+      <child link="${name}_nil_link"/>
+      <insert_block name="origin"/>
+    </joint>
+  </macro>
+</robot>

--- a/eusurdf/textured_models/room73b2-wanda/model.urdf.xacro
+++ b/eusurdf/textured_models/room73b2-wanda/model.urdf.xacro
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='utf-8'?>
+<robot xmlns:xi="http://www.w3.org/2001/XInclude" name="room73b2-wanda">
+  <macro name="room73b2-wanda" params="name parent *origin">
+    <gazebo>
+      <static>false</static>
+    </gazebo>
+    <link name="${name}_nil_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-wanda/meshes/nil_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <geometry>
+          <mesh filename="model://room73b2-wanda/meshes/nil_link_mesh.dae" scale="1 1 1"/>
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="0.3"/>
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="1e-03" ixy="0" ixz="0" iyy="1e-03" iyz="0" izz="1e-03"/>
+      </inertial>
+    </link>
+    <gazebo reference="${name}_nil_link">
+      <mu1>0.9</mu1>
+      <mu2>0.9</mu2>
+    </gazebo>
+    <joint name="${name}_root_parent_joint" type="fixed">
+      <parent link="${parent}"/>
+      <child link="${name}_nil_link"/>
+      <insert_block name="origin"/>
+    </joint>
+  </macro>
+</robot>


### PR DESCRIPTION
automatically generates urdf.xacro file for eus scene.

sample:
https://gist.github.com/f55fb768af9d73ad903fe1cdd94bb8b4

You can generate one urdf file for each scene and spawn with `rosrun gazebo_ros spawn_model` to gazebo.

```xml
<launch>
  <!-- spawn /home/furushchev/ros/bremen/catkin_ws/src/jsk_model_tools/eusurdf/worlds/room73b2.urdf.xacro to gazebo -->
  <arg name="model" default="/home/furushchev/ros/bremen/catkin_ws/src/jsk_model_tools/eusurdf/worlds/room73b2.urdf.xacro"/>
  <param name="room73b2_description" command="$(find xacro)/xacro.py '$(arg model)'"/>
  <node name="spawn_room73b2" pkg="gazebo_ros" type="spawn_model"
        args="-param room73b2_description -urdf -model room73b2"/>
</launch>
```