### PR TITLE
add python-lxml to run_depends

### DIFF
--- a/eusurdf/package.xml
+++ b/eusurdf/package.xml
@@ -20,6 +20,7 @@
   <build_depend>collada_urdf_jsk_patch</build_depend>
   <build_depend>roseus</build_depend>
   <build_depend>rostest</build_depend>
+  <build_depend>python-lxml</build_depend>
 
   <run_depend>collada_urdf_jsk_patch</run_depend>
   <run_depend>gazebo_ros</run_depend>


### PR DESCRIPTION
fix http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__eusurdf__ubuntu_xenial_amd64__binary/1/console