### PR TITLE
use language: c++ , to avoid custom python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: generic
+language: c++
 notifications:
   email:
     on_success: always


### PR DESCRIPTION
need to use system python, with travis-python we can not find python module install by apt
c.f. jsk-ros-pkg/jsk_3rdparty#117