### PR TITLE
[eus_assimp] need to set faces before calling gl::make-glvertices-fro…

### DIFF
--- a/eus_assimp/euslisp/eus-assimp.l
+++ b/eus_assimp/euslisp/eus-assimp.l
@@ -242,6 +242,7 @@
      ((find-method obj :bodies)
       (let (glv-lst)
         (dolist (bd (send obj :bodies))
+          (setq faces (send bd :faces))
           (let (mat)
             (if material (setq mat material))
             ;; TODO: get color and set matterial


### PR DESCRIPTION
…m-faces

``dump-to-meshfile`` did not work because ``faces`` in ``(funcall #'gl::make-glvertices-from-faces faces :material mat)`` was not set and it was nil.

```lisp
(progn                                                                          
  (load "package://pr2eus/pr2.l")                                               
  (load "package://eus_assimp/euslisp/eus-assimp.l")                            
  (setq *robot* (pr2))                                                          
  (objects (list *robot*))                                                      
  (dump-to-meshfile "/tmp/robot.stl" *robot*)                                   
  (unix::system "meshlab /tmp/robot.stl"))
```

![image](https://user-images.githubusercontent.com/4509039/28323780-b4058c96-6c14-11e7-9ed8-c39530b2911f.png)

---

By the way,,,
Could you suggest some ideas about how to get a fine/detailed single whole-body STL file (pr2_whole_body.stl) from a URDF robot model having multiple links (pr2.urdf).
For example, **if we want to create a PR2 key holder by 3D printer**, we need to generate one fine/detailed STL file.

After JSK conventional urdf -> collada -> euslisp conversion, I tried to convert the euslisp model to a STL file with this PR, but the output STL files looks like convex hull and it is not a fine/detailed STL file.
Also, I tried to convert collada -> STL with meshlab, but meshlab does not understand translation information and all the links are located at world origin as follows.

![image](https://user-images.githubusercontent.com/4509039/28368807-9f83228a-6cd0-11e7-9e18-491d9fc479af.png)
