### PR TITLE
since euslisp 9.25.0, we need to add 5 arguments including doc string with defun()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,10 @@ env:
   matrix:
     - ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=true
     - ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - ROS_DISTRO=jade   ROSWS=wstool BUILDER=catkin USE_DEB=true
-    - ROS_DISTRO=jade   ROSWS=wstool BUILDER=catkin USE_DEB=false
     - ROS_DISTRO=kinetic   ROSWS=wstool BUILDER=catkin USE_DEB=true
     - ROS_DISTRO=kinetic   ROSWS=wstool BUILDER=catkin USE_DEB=false
 matrix:
   allow_failures:
-    - env: ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin USE_DEB=false EXTRA_DEB=ros-hydro-urdfdom
     - env: ROS_DISTRO=indigo ROSWS=wstool BUILDER=catkin USE_DEB=false
-    - env: ROS_DISTRO=jade   ROSWS=wstool BUILDER=catkin USE_DEB=false
     - env: ROS_DISTRO=kinetic   ROSWS=wstool BUILDER=catkin USE_DEB=false
 script: source .travis/travis.sh

--- a/eus_assimp/package.xml
+++ b/eus_assimp/package.xml
@@ -13,11 +13,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>euslisp</build_depend>
+  <build_depend version_gte="9.25.0">euslisp</build_depend>
   <build_depend>assimp_devel</build_depend>
   <build_depend>pkg-config</build_depend>
 
-  <run_depend>roseus</run_depend>
+  <run_depend version_gte="1.7.1">roseus</run_depend>
   <run_depend>assimp_devel</run_depend>
 
   <!-- <test_depend>euslisp</test_depend> -->

--- a/eus_assimp/src/eus_assimp.cpp
+++ b/eus_assimp/src/eus_assimp.cpp
@@ -1468,12 +1468,12 @@ pointer ASSIMP_LOAD_IMAGE(register context *ctx,int n,pointer *argv)
 
 pointer ___eus_assimp(register context *ctx, int n, pointer *argv, pointer env)
 {
-  defun(ctx,"C-ASSIMP-GET-GLVERTICES", argv[0], (pointer (*)())GET_MESHES);
-  defun(ctx,"C-ASSIMP-DUMP-GLVERTICES", argv[0], (pointer (*)())DUMP_GL_VERTICES);
-  defun(ctx,"C-CONVEX-DECOMPOSITION-GLVERTICES", argv[0], (pointer (*)())CONVEX_DECOMP_GL_VERTICES);
-  defun(ctx,"C-ASSIMP-DESCRIBE", argv[0], (pointer (*)())ASSIMP_DESCRIBE);
+  defun(ctx,"C-ASSIMP-GET-GLVERTICES", argv[0], (pointer (*)())GET_MESHES, NULL);
+  defun(ctx,"C-ASSIMP-DUMP-GLVERTICES", argv[0], (pointer (*)())DUMP_GL_VERTICES, NULL);
+  defun(ctx,"C-CONVEX-DECOMPOSITION-GLVERTICES", argv[0], (pointer (*)())CONVEX_DECOMP_GL_VERTICES, NULL);
+  defun(ctx,"C-ASSIMP-DESCRIBE", argv[0], (pointer (*)())ASSIMP_DESCRIBE, NULL);
 #if USE_SDL_IMAGE
-  defun(ctx,"C-ASSIMP-LOAD-IMAGE", argv[0], (pointer (*)())ASSIMP_LOAD_IMAGE);
+  defun(ctx,"C-ASSIMP-LOAD-IMAGE", argv[0], (pointer (*)())ASSIMP_LOAD_IMAGE, NULL);
 #endif
 
   K_VERTICES  = defkeyword(ctx, "VERTICES");


### PR DESCRIPTION
failing on build firm : http://build.ros.org/view/Ksrc_uX/job/Kbin_uX64__eus_assimp__ubuntu_xenial_amd64__binary/

c.f. https://github.com/euslisp/EusLisp/pull/300