### PR TITLE
add mimic joint support for collada2eus

### DIFF
--- a/euscollada/CMakeLists.txt
+++ b/euscollada/CMakeLists.txt
@@ -68,3 +68,4 @@ install(PROGRAMS ${_install_sh_files}
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 add_rostest(test/euscollada-model-conversion.test)
+add_rostest(test/test-mimic.test)

--- a/euscollada/pr2-mimic.sh
+++ b/euscollada/pr2-mimic.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+if [ -w `rospack find euscollada` ]; then
+    cd `rospack find euscollada`
+else
+    echo "euscollada direcotry is not writable, so write to current directory"
+fi
+
+#rosrun collada_urdf_jsk_patch urdf_to_collada `rospack find pr2_mechanism_model`/pr2.urdf pr2.dae
+if [ -e `rospack find pr2_mechanism_model`/pr2.urdf ];
+then
+    rosrun collada_urdf urdf_to_collada `rospack find pr2_mechanism_model`/pr2.urdf pr2.dae
+else
+    rosrun xacro xacro.py `rospack find pr2_description`/robots/pr2.urdf.xacro > /tmp/pr2.$$.urdf
+    rosrun collada_urdf urdf_to_collada /tmp/pr2.$$.urdf pr2.dae
+fi
+if [ "$?" != 0 ] ;  then exit ; fi
+
+rosrun euscollada collada2eus pr2.dae `rospack find euscollada`/pr2-mimic.yaml pr2-mimic.l.$$.tmp; mv pr2-mimic.l.$$.tmp pr2-mimic.l
+if [ "$?" != 0 ] ;  then exit ; fi
+
+rosrun roseus roseus lib/llib/unittest.l "(init-unit-test)" "\
+(progn									\
+  (load \"pr2-mimic.l\")					\
+  (if (and x::*display* (> x::*display* 0) (not (boundp '*irtviewer*))) (make-irtviewer :title \"pr2.sh\"))			\
+  (if (not (boundp '*pr2*)) (pr2))					\
+									\
+  (when (boundp '*irtviewer*) (objects (list *pr2*)))			\
+  (setq i 0.0)								\
+  (do-until-key								\
+   (send *pr2* :r_gripper :joint-angle i)				\
+   (print (list i (send *pr2* :r_gripper_l_finger_joint :joint-angle)	\
+              (send *pr2* :r_gripper_r_finger_joint :joint-angle)	\
+              (send *pr2* :r_gripper_l_finger_tip_joint :joint-angle)	\
+              (send *pr2* :r_gripper_r_finger_tip_joint :joint-angle)))	\
+   (assert (eps= (send *pr2* :r_gripper_r_finger_joint :joint-angle)    \
+                 (send *pr2* :r_gripper_l_finger_joint :joint-angle)))	\
+   (assert (eps= (send *pr2* :r_gripper_r_finger_joint :joint-angle)    \
+                 (send *pr2* :r_gripper_l_finger_tip_joint :joint-angle)))	\
+   (assert (eps= (send *pr2* :r_gripper_r_finger_joint :joint-angle)    \
+                 (send *pr2* :r_gripper_r_finger_tip_joint :joint-angle)))	\
+   (when (boundp '*irtviewer*)						\
+	(send *irtviewer* :draw-objects)				\
+	)						\
+   (incf i)								\
+   (when (> i 30) (exit 0))						\
+   )									\
+  (if (boundp '*irtviewer*) (send-all (send *pr2* :links) :draw-on :flush t))\
+  (exit)                                                                \
+  )									\
+"

--- a/euscollada/pr2-mimic.yaml
+++ b/euscollada/pr2-mimic.yaml
@@ -1,0 +1,8 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+larm:
+  - r_gripper_l_finger_joint : r_gripper
+rarm:
+  - l_gripper_l_finger_joint : l_gripper

--- a/euscollada/src/collada2eus_urdfmodel.cpp
+++ b/euscollada/src/collada2eus_urdfmodel.cpp
@@ -1030,6 +1030,14 @@ void ModelEuslisp::printMimicJoints () {
       fprintf(fp, "            (instance mimic-joint-param :init %s_jt :multiplier %f :offset %f)\n", (*joint)->name.c_str(), (*joint)->mimic->multiplier, (*joint)->mimic->offset);
     }
     fprintf(fp, "            ))\n");
+    fprintf(fp, "     ;; set offset as default-coords\n");
+    fprintf(fp, "     (dolist (j (%s_jt . mimic-joints))\n", mimic->first->name.c_str());
+    fprintf(fp, "       (cond ((derivedp (send j :joint) rotational-joint)\n");
+    fprintf(fp, "              (send (send j :joint :child-link) :rotate (send j :offset) ((send j :joint) . axis)))\n");
+    fprintf(fp, "             ((derivedp (send j :joint) linear-joint)\n");
+    fprintf(fp, "              (send (send j :joint :child-link) :translate (scale (* 1000 (send j :offset)) ((send j :joint) . axis))))\n");
+    fprintf(fp, "             (t (error \"unsupported mimic joint ~A\" (send j :joint))))\n");
+    fprintf(fp, "       (setq ((send j :joint) . default-coords) (send j :joint :child-link :copy-coords)))\n");
   }
 }
 

--- a/euscollada/src/euscollada-robot.l
+++ b/euscollada/src/euscollada-robot.l
@@ -151,6 +151,47 @@
   (:offset (&rest args) (forward-message-to offset args))
   )
 
+(defun calc-jacobian-mimic
+  (mimic-joints
+       fik row column joint paxis child-link world-default-coords child-reverse
+       move-target transform-coords rotation-axis translation-axis
+       tmp-v0 tmp-v1 tmp-v2 tmp-v3 tmp-v3a tmp-v3b tmp-m33)
+  (let* ((fik-tmp (copy-object fik))
+         (dim (* 6 (if (atom rotation-axis) 1 (length rotation-axis)))))
+    (dolist (axis (append (if (atom translation-axis)
+                              (list translation-axis) translation-axis)
+                          (if (atom rotation-axis)
+                              (list rotation-axis) rotation-axis)))
+      (case axis
+            ((:x :y :z :xx :yy :zz) (decf dim 1))
+            ((:xy :yx :yz :zy :zx :xz) (decf dim 2))
+            (nil (decf dim 3))))
+     ;;
+     (dolist (mj mimic-joints)
+       (let* ((j (send mj :joint))
+              (paxis (case (j . axis)
+                           (:x #f(1 0 0)) (:y #f(0 1 0)) (:z #f(0 0 1))
+                           (:xx #f(1 0 0)) (:yy #f(0 1 0)) (:zz #f(0 0 1))
+                           (:-x #f(-1 0 0)) (:-y #f(0 -1 0)) (:-z #f(0 0 -1))
+                           (t (j . axis))))
+              (child-link (send j :child-link))
+              (parent-link (send j :parent-link))
+              (default-coords (j . default-coords))
+              (world-default-coords (send (send parent-link :copy-worldcoords)
+                                          :transform default-coords)))
+         (fill (array-entity fik-tmp) 0)
+         (send j :calc-jacobian
+               fik-tmp row column j paxis child-link world-default-coords child-reverse
+               move-target transform-coords rotation-axis translation-axis
+               tmp-v0 tmp-v1 tmp-v2 tmp-v3 tmp-v3a tmp-v3b tmp-m33)
+         ;;
+         (dotimes (i dim)
+           (setf (aref fik (+ i row) column)
+                 (+ (aref fik (+ i row) column)
+                    (* (send mj :multiplier) (aref fik-tmp (+ i row) column)))))
+         ))
+     fik))
+
 (defclass rotational-mimic-joint
        :super rotational-joint
        :slots (mimic-joints))
@@ -158,13 +199,27 @@
   (:init (&rest args &key ((:mimic-joints mjs)) &allow-other-keys)
          (send-super* :init args)
          (setq mimic-joints mjs)
+         (dolist (j mimic-joints)
+           (send (send j :joint :child-link) :rotate (send j :offset) ((send j :joint) . axis))
+           (setq ((send j :joint) . default-coords) (send j :joint :child-link :copy-coords)))
          self)
   (:joint-angle (&rest args)
          (prog1
              (send-super* :joint-angle args)
            (dolist (j mimic-joints)
-             (send j :joint :joint-angle (+ (* joint-angle (send j :multiplier)) (send j :offset))))
+             (send j :joint :joint-angle (* joint-angle (send j :multiplier))))
            ))
+  (:calc-jacobian (fik row column joint paxis child-link world-default-coords child-reverse
+                       move-target transform-coords rotation-axis translation-axis
+                       tmp-v0 tmp-v1 tmp-v2 tmp-v3 tmp-v3a tmp-v3b tmp-m33)
+         (calc-jacobian-rotational fik row column joint paxis child-link world-default-coords child-reverse
+                                   move-target transform-coords rotation-axis translation-axis
+                                   tmp-v0 tmp-v1 tmp-v2 tmp-v3 tmp-v3a tmp-v3b tmp-m33)
+         (calc-jacobian-mimic mimic-joints
+                              fik row column joint paxis child-link world-default-coords child-reverse
+                              move-target transform-coords rotation-axis translation-axis
+                              tmp-v0 tmp-v1 tmp-v2 tmp-v3 tmp-v3a tmp-v3b tmp-m33)
+         ))
   )
 
 (defclass linear-mimic-joint
@@ -174,11 +229,25 @@
   (:init (&rest args &key ((:mimic-joints mjs)) &allow-other-keys)
          (send-super* :init args)
          (setq mimic-joints mjs)
+         (dolist (j mimic-joints)
+           (send (send j :joint :child-link) :translate (scale (* 1000 (send j :offset)) ((send j :joint) . axis)))
+           (setq ((send j :joint) . default-coords) (send j :joint :child-link :copy-coords)))
          self)
   (:joint-angle (&rest args)
          (prog1
              (send-super* :joint-angle args)
            (dolist (j mimic-joints)
-             (send j :joint :joint-angle (+ (* joint-angle (send j :multiplier)) (send j :offset))))
+             (send j :joint :joint-angle (* joint-angle (send j :multiplier))))
            ))
+  (:calc-jacobian (fik row column joint paxis child-link world-default-coords child-reverse
+                       move-target transform-coords rotation-axis translation-axis
+                       tmp-v0 tmp-v1 tmp-v2 tmp-v3 tmp-v3a tmp-v3b tmp-m33)
+         (calc-jacobian-linear fik row column joint paxis child-link world-default-coords child-reverse
+                               move-target transform-coords rotation-axis translation-axis
+                               tmp-v0 tmp-v1 tmp-v2 tmp-v3 tmp-v3a tmp-v3b tmp-m33)
+         (calc-jacobian-mimic mimic-joints
+                              fik row column joint paxis child-link world-default-coords child-reverse
+                              move-target transform-coords rotation-axis translation-axis
+                              tmp-v0 tmp-v1 tmp-v2 tmp-v3 tmp-v3a tmp-v3b tmp-m33)
+         ))
   )

--- a/euscollada/src/euscollada-robot.l
+++ b/euscollada/src/euscollada-robot.l
@@ -136,3 +136,49 @@
           org-mesh)))
      ))
   )
+
+;; copy mimic-joint class definition from euscollada/src/euscollada-robot.l
+;; This mimic-joint class is for mimic-joints in URDF file
+(defclass mimic-joint-param
+  :super propertied-object
+  :slots (joint multiplier offset))
+(defmethod mimic-joint-param
+  (:init (j &key ((:multiplier m) 1) ((:offset o) 0))
+         (setq joint j multiplier m offset o)
+         self)
+  (:joint (&rest args) (forward-message-to joint args))
+  (:multiplier (&rest args) (forward-message-to multiplier args))
+  (:offset (&rest args) (forward-message-to offset args))
+  )
+
+(defclass rotational-mimic-joint
+       :super rotational-joint
+       :slots (mimic-joints))
+(defmethod rotational-mimic-joint
+  (:init (&rest args &key ((:mimic-joints mjs)) &allow-other-keys)
+         (send-super* :init args)
+         (setq mimic-joints mjs)
+         self)
+  (:joint-angle (&rest args)
+         (prog1
+             (send-super* :joint-angle args)
+           (dolist (j mimic-joints)
+             (send j :joint :joint-angle (+ (* joint-angle (send j :multiplier)) (send j :offset))))
+           ))
+  )
+
+(defclass linear-mimic-joint
+       :super linear-joint
+       :slots (mimic-joints))
+(defmethod linear-mimic-joint
+  (:init (&rest args &key ((:mimic-joints mjs)) &allow-other-keys)
+         (send-super* :init args)
+         (setq mimic-joints mjs)
+         self)
+  (:joint-angle (&rest args)
+         (prog1
+             (send-super* :joint-angle args)
+           (dolist (j mimic-joints)
+             (send j :joint :joint-angle (+ (* joint-angle (send j :multiplier)) (send j :offset))))
+           ))
+  )

--- a/euscollada/test/euscollada-model-conversion-test.l
+++ b/euscollada/test/euscollada-model-conversion-test.l
@@ -33,6 +33,7 @@
         (assert (select-stream (list strm) 120) ";; ;; faild to generate /tmp/pr2.dae within 120 second")
         (close strm))
     (let ((strm (piped-fork "rosrun xacro xacro.py `rospack find pr2_description`/robots/pr2.urdf.xacro > /tmp/pr2.$$.urdf && rosrun collada_urdf urdf_to_collada /tmp/pr2.$$.urdf /tmp/pr2.dae")))
+      (format *error-output* ";; check /tmp/pr2.dae file is generetad within 120 second .. ~A~%" (select-stream (list strm) 120)) ;; not sure why but we need double check since https://travis-ci.org/jsk-ros-pkg/jsk_model_tools/builds/632871892
       (assert (select-stream (list strm) 120) ";; faild to generate /tmp/pr2.dae within 120 second")
       (close strm))
     )

--- a/euscollada/test/robots/test-linear-1.urdf
+++ b/euscollada/test/robots/test-linear-1.urdf
@@ -1,0 +1,136 @@
+<?xml version="1.0"?>
+<robot name="linear_1">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link1">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link2">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 1.5708 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link3">
+    <visual>
+      <origin xyz="0 0 -0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link4">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link5">
+    <visual>
+      <origin xyz="0 0 0.0828" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1656" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link6">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint2" type="prismatic">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.3" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint3" type="prismatic">
+    <parent link="link2"/>
+    <child link="link3"/>
+    <origin xyz="0.6 0 0" rpy="3.14159 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint4" type="revolute">
+    <parent link="link3"/>
+    <child link="link4"/>
+    <origin xyz="0 0 0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint5" type="revolute">
+    <parent link="link4"/>
+    <child link="link5"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint6" type="revolute">
+    <parent link="link5"/>
+    <child link="link6"/>
+    <origin xyz="0 0 0.1656" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+
+</robot>

--- a/euscollada/test/robots/test-linear-1.yaml
+++ b/euscollada/test/robots/test-linear-1.yaml
@@ -1,0 +1,19 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+rarm:
+  - joint1 : rarm-shoulder-y
+  - joint2 : rarm-shoulder-p
+  - joint3 : rarm-elbow-p
+  - joint4 : rarm-wrist-p
+  - joint5 : rarm-wrist-r
+  - joint6 : rarm-wrist-y
+
+##
+## end-coords
+##
+rarm-end-coords:
+  translate : [0, 0, 0.2 ]
+  rotate    : [0, 0, 1, 0]
+  parent    : link6

--- a/euscollada/test/robots/test-linear-mimic-1.urdf
+++ b/euscollada/test/robots/test-linear-mimic-1.urdf
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<robot name="linear_mimic_1">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link1">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link2">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 1.5708 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link3">
+    <visual>
+      <origin xyz="0 0 -0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link4">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link5">
+    <visual>
+      <origin xyz="0 0 0.0828" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1656" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link6">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint2" type="prismatic">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.3" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint3" type="prismatic">
+    <parent link="link2"/>
+    <child link="link3"/>
+    <origin xyz="0.6 0 0" rpy="3.14159 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+    <mimic joint="joint2" multiplier="2.0" offset="0" />
+  </joint>
+
+  <joint name="joint4" type="revolute">
+    <parent link="link3"/>
+    <child link="link4"/>
+    <origin xyz="0 0 0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint5" type="revolute">
+    <parent link="link4"/>
+    <child link="link5"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint6" type="revolute">
+    <parent link="link5"/>
+    <child link="link6"/>
+    <origin xyz="0 0 0.1656" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+
+</robot>

--- a/euscollada/test/robots/test-linear-mimic-1.yaml
+++ b/euscollada/test/robots/test-linear-mimic-1.yaml
@@ -1,0 +1,18 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+rarm:
+  - joint1 : rarm-shoulder-y
+  - joint2 : rarm-shoulder-p
+  - joint4 : rarm-wrist-p
+  - joint5 : rarm-wrist-r
+  - joint6 : rarm-wrist-y
+
+##
+## end-coords
+##
+rarm-end-coords:
+  translate : [0, 0, 0.2 ]
+  rotate    : [0, 0, 1, 0]
+  parent    : link6

--- a/euscollada/test/robots/test-linear-mimic-2.urdf
+++ b/euscollada/test/robots/test-linear-mimic-2.urdf
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<robot name="linear_mimic_2">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link1">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link2">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 1.5708 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link3">
+    <visual>
+      <origin xyz="0 0 -0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link4">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link5">
+    <visual>
+      <origin xyz="0 0 0.0828" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1656" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link6">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint2" type="prismatic">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.3" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint3" type="prismatic">
+    <parent link="link2"/>
+    <child link="link3"/>
+    <origin xyz="0.6 0 0" rpy="3.14159 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+    <mimic joint="joint2" multiplier="1.0" offset="0.45" />
+  </joint>
+
+  <joint name="joint4" type="revolute">
+    <parent link="link3"/>
+    <child link="link4"/>
+    <origin xyz="0 0 0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint5" type="revolute">
+    <parent link="link4"/>
+    <child link="link5"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint6" type="revolute">
+    <parent link="link5"/>
+    <child link="link6"/>
+    <origin xyz="0 0 0.1656" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+
+</robot>

--- a/euscollada/test/robots/test-linear-mimic-2.yaml
+++ b/euscollada/test/robots/test-linear-mimic-2.yaml
@@ -1,0 +1,18 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+rarm:
+  - joint1 : rarm-shoulder-y
+  - joint2 : rarm-shoulder-p
+  - joint4 : rarm-wrist-p
+  - joint5 : rarm-wrist-r
+  - joint6 : rarm-wrist-y
+
+##
+## end-coords
+##
+rarm-end-coords:
+  translate : [0, 0, 0.2 ]
+  rotate    : [0, 0, 1, 0]
+  parent    : link6

--- a/euscollada/test/robots/test-revolute-1.urdf
+++ b/euscollada/test/robots/test-revolute-1.urdf
@@ -1,0 +1,136 @@
+<?xml version="1.0"?>
+<robot name="revolute_1">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link1">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link2">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link3">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link4">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link5">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link6">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint2" type="revolute">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint3" type="revolute">
+    <parent link="link2"/>
+    <child link="link3"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint4" type="revolute">
+    <parent link="link3"/>
+    <child link="link4"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint5" type="revolute">
+    <parent link="link4"/>
+    <child link="link5"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint6" type="revolute">
+    <parent link="link5"/>
+    <child link="link6"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+
+</robot>

--- a/euscollada/test/robots/test-revolute-1.yaml
+++ b/euscollada/test/robots/test-revolute-1.yaml
@@ -1,0 +1,19 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+rarm:
+  - joint1 : rarm-shoulder-y
+  - joint2 : rarm-shoulder-p
+  - joint3 : rarm-elbow-p
+  - joint4 : rarm-wrist-p
+  - joint5 : rarm-wrist-r
+  - joint6 : rarm-wrist-y
+
+##
+## end-coords
+##
+rarm-end-coords:
+  translate : [0, 0, 0.2 ]
+  rotate    : [0, 0, 1, 0]
+  parent    : link6

--- a/euscollada/test/robots/test-revolute-2.urdf
+++ b/euscollada/test/robots/test-revolute-2.urdf
@@ -1,0 +1,136 @@
+<?xml version="1.0"?>
+<robot name="revolute_2">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link1">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link2">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link3">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link4">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link5">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link6">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint2" type="revolute">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint3" type="revolute">
+    <parent link="link2"/>
+    <child link="link3"/>
+    <origin xyz="0 0 1.0" rpy="0 0.785398 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint4" type="revolute">
+    <parent link="link3"/>
+    <child link="link4"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint5" type="revolute">
+    <parent link="link4"/>
+    <child link="link5"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint6" type="revolute">
+    <parent link="link5"/>
+    <child link="link6"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+
+</robot>

--- a/euscollada/test/robots/test-revolute-2.yaml
+++ b/euscollada/test/robots/test-revolute-2.yaml
@@ -1,0 +1,19 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+rarm:
+  - joint1 : rarm-shoulder-y
+  - joint2 : rarm-shoulder-p
+  - joint3 : rarm-elbow-p
+  - joint4 : rarm-wrist-p
+  - joint5 : rarm-wrist-r
+  - joint6 : rarm-wrist-y
+
+##
+## end-coords
+##
+rarm-end-coords:
+  translate : [0, 0, 0.2 ]
+  rotate    : [0, 0, 1, 0]
+  parent    : link6

--- a/euscollada/test/robots/test-revolute-mimic-1.urdf
+++ b/euscollada/test/robots/test-revolute-mimic-1.urdf
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<robot name="revolute_mimic_1">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link1">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link2">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link3">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link4">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link5">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link6">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint2" type="revolute">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint3" type="revolute">
+    <parent link="link2"/>
+    <child link="link3"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+    <mimic joint="joint2" multiplier="2.0" offset="0" />
+  </joint>
+
+  <joint name="joint4" type="revolute">
+    <parent link="link3"/>
+    <child link="link4"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint5" type="revolute">
+    <parent link="link4"/>
+    <child link="link5"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint6" type="revolute">
+    <parent link="link5"/>
+    <child link="link6"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+
+</robot>

--- a/euscollada/test/robots/test-revolute-mimic-1.yaml
+++ b/euscollada/test/robots/test-revolute-mimic-1.yaml
@@ -1,0 +1,18 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+rarm:
+  - joint1 : rarm-shoulder-y
+  - joint2 : rarm-shoulder-p
+  - joint4 : rarm-wrist-p
+  - joint5 : rarm-wrist-r
+  - joint6 : rarm-wrist-y
+
+##
+## end-coords
+##
+rarm-end-coords:
+  translate : [0, 0, 0.2 ]
+  rotate    : [0, 0, 1, 0]
+  parent    : link6

--- a/euscollada/test/robots/test-revolute-mimic-2.urdf
+++ b/euscollada/test/robots/test-revolute-mimic-2.urdf
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<robot name="revolute_mimic_2">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link1">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link2">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link3">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link4">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link5">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link6">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint2" type="revolute">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 -1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint3" type="revolute">
+    <parent link="link2"/>
+    <child link="link3"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+    <mimic joint="joint2" multiplier="-2.0" offset="0" />
+  </joint>
+
+  <joint name="joint4" type="revolute">
+    <parent link="link3"/>
+    <child link="link4"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint5" type="revolute">
+    <parent link="link4"/>
+    <child link="link5"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint6" type="revolute">
+    <parent link="link5"/>
+    <child link="link6"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+
+</robot>

--- a/euscollada/test/robots/test-revolute-mimic-2.yaml
+++ b/euscollada/test/robots/test-revolute-mimic-2.yaml
@@ -1,0 +1,18 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+rarm:
+  - joint1 : rarm-shoulder-y
+  - joint2 : rarm-shoulder-p
+  - joint4 : rarm-wrist-p
+  - joint5 : rarm-wrist-r
+  - joint6 : rarm-wrist-y
+
+##
+## end-coords
+##
+rarm-end-coords:
+  translate : [0, 0, 0.2 ]
+  rotate    : [0, 0, 1, 0]
+  parent    : link6

--- a/euscollada/test/robots/test-revolute-mimic-3.urdf
+++ b/euscollada/test/robots/test-revolute-mimic-3.urdf
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<robot name="revolute_mimic_3">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link1">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link2">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link3">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link4">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link5">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link6">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint2" type="revolute">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint3" type="revolute">
+    <parent link="link2"/>
+    <child link="link3"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+    <mimic joint="joint2" multiplier="1.0" offset="0.785398" />
+  </joint>
+
+  <joint name="joint4" type="revolute">
+    <parent link="link3"/>
+    <child link="link4"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint5" type="revolute">
+    <parent link="link4"/>
+    <child link="link5"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint6" type="revolute">
+    <parent link="link5"/>
+    <child link="link6"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+
+</robot>

--- a/euscollada/test/robots/test-revolute-mimic-3.yaml
+++ b/euscollada/test/robots/test-revolute-mimic-3.yaml
@@ -1,0 +1,18 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+rarm:
+  - joint1 : rarm-shoulder-y
+  - joint2 : rarm-shoulder-p
+  - joint4 : rarm-wrist-p
+  - joint5 : rarm-wrist-r
+  - joint6 : rarm-wrist-y
+
+##
+## end-coords
+##
+rarm-end-coords:
+  translate : [0, 0, 0.2 ]
+  rotate    : [0, 0, 1, 0]
+  parent    : link6

--- a/euscollada/test/robots/test-revolute-mimic-4.urdf
+++ b/euscollada/test/robots/test-revolute-mimic-4.urdf
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<robot name="revolute_mimic_4">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link1">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link2">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link3">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link4">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link5">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link6">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint2" type="revolute">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 -1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint3" type="revolute">
+    <parent link="link2"/>
+    <child link="link3"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+    <mimic joint="joint2" multiplier="-1.0" offset="0.785398" />
+  </joint>
+
+  <joint name="joint4" type="revolute">
+    <parent link="link3"/>
+    <child link="link4"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint5" type="revolute">
+    <parent link="link4"/>
+    <child link="link5"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint6" type="revolute">
+    <parent link="link5"/>
+    <child link="link6"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+
+</robot>

--- a/euscollada/test/robots/test-revolute-mimic-4.yaml
+++ b/euscollada/test/robots/test-revolute-mimic-4.yaml
@@ -1,0 +1,18 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+rarm:
+  - joint1 : rarm-shoulder-y
+  - joint2 : rarm-shoulder-p
+  - joint4 : rarm-wrist-p
+  - joint5 : rarm-wrist-r
+  - joint6 : rarm-wrist-y
+
+##
+## end-coords
+##
+rarm-end-coords:
+  translate : [0, 0, 0.2 ]
+  rotate    : [0, 0, 1, 0]
+  parent    : link6

--- a/euscollada/test/robots/test-revolute-mimic-5.urdf
+++ b/euscollada/test/robots/test-revolute-mimic-5.urdf
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<robot name="revolute_mimic_5">
+  <link name="base_link">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link1">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link2">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link3">
+    <visual>
+      <origin xyz="0 0 0.5" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 1.0" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link4">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="green">
+        <color rgba="0 1 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link5">
+    <visual>
+      <origin xyz="0 0 0.05" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.1" />
+      </geometry>
+      <material name="blue">
+        <color rgba="0 0 1 1" />
+      </material>
+    </visual>
+  </link>
+
+  <link name="link6">
+    <visual>
+      <origin xyz="0 0 0.1" rpy="0 0 0" />
+      <geometry>
+        <box size="0.2 0.2 0.2" />
+      </geometry>
+      <material name="red">
+        <color rgba="1 0 0 1" />
+      </material>
+    </visual>
+  </link>
+
+  <joint name="joint1" type="revolute">
+    <parent link="base_link"/>
+    <child link="link1"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint2" type="revolute">
+    <parent link="link1"/>
+    <child link="link2"/>
+    <origin xyz="0 0 0.2" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint3" type="revolute">
+    <parent link="link2"/>
+    <child link="link3"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+    <mimic joint="joint1" multiplier="2.0" offset="0" />
+  </joint>
+
+  <joint name="joint4" type="revolute">
+    <parent link="link3"/>
+    <child link="link4"/>
+    <origin xyz="0 0 1.0" rpy="0 0 0" />
+    <axis xyz="0 1 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint5" type="revolute">
+    <parent link="link4"/>
+    <child link="link5"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="1 0 0" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+  <joint name="joint6" type="revolute">
+    <parent link="link5"/>
+    <child link="link6"/>
+    <origin xyz="0 0 0.1" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="-2.36" upper="2.36" effort="1" velocity="1" />
+  </joint>
+
+
+</robot>

--- a/euscollada/test/robots/test-revolute-mimic-5.yaml
+++ b/euscollada/test/robots/test-revolute-mimic-5.yaml
@@ -1,0 +1,18 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+rarm:
+  - joint1 : rarm-shoulder-y
+  - joint2 : rarm-shoulder-p
+  - joint4 : rarm-wrist-p
+  - joint5 : rarm-wrist-r
+  - joint6 : rarm-wrist-y
+
+##
+## end-coords
+##
+rarm-end-coords:
+  translate : [0, 0, 0.2 ]
+  rotate    : [0, 0, 1, 0]
+  parent    : link6

--- a/euscollada/test/test-mimic.l
+++ b/euscollada/test/test-mimic.l
@@ -1,0 +1,137 @@
+(require :unittest "lib/llib/unittest.l")
+
+(init-unit-test)
+
+;; copy from euscollada-model-conversion-test.l
+(defun generate-eusmodel-from-collada (col-file eus-file &key (yaml-file))
+  (let ((strm (piped-fork
+               (if yaml-file
+                   (format nil "rosrun euscollada collada2eus ~A ~A ~A && echo finished"
+                           col-file yaml-file eus-file)
+                 (format nil "rosrun euscollada collada2eus ~A ~A && echo finished"
+                         col-file eus-file)))))
+    ;; (assert (select-stream (list strm) 240) (format nil ";; faild to generate ~A within 240 second" eus-file)) ;; why return nil immidiately
+    (dotimes (i 240)
+      (when
+	  (while (and (select-stream (list strm) 1)
+		      (not (eq :eof (read-line strm nil :eof))))
+	    (return t))
+	(return))
+      (assert (/= i  239) (format nil ";; faild to generate ~A within 240 second" eus-file))
+      (unix::sleep 1)
+      )
+    (unix::sleep 1)
+    (close strm)
+    ))
+
+(load "package://euscollada/src/euscollada-robot.l")
+(defvar *loop* 0)
+(defmethod euscollada-robot
+  (:inverse-kinematics-loop (&rest args)
+     (incf *loop*)
+     (send-super* :inverse-kinematics-loop args)))
+
+(defun test-mimic-joint (name)
+  (let ((urdf-file (ros::resolve-ros-path (format nil "package://euscollada/test/robots/test-~A.urdf" name)))
+        (yaml-file (ros::resolve-ros-path (format nil "package://euscollada/test/robots/test-~A.yaml" name)))
+        (eus-file (format nil "/tmp/test-~A.l" name))
+        param len av robot end-coords goal ret)
+    (generate-eusmodel-from-collada urdf-file eus-file :yaml-file yaml-file)
+    (load eus-file)
+    (setq robot (funcall (intern (string-upcase (substitute #\_ #\- name)))))
+    (format t "create robot model ~A~%" robot)
+    (setq param (list (cons (send robot :joint1)  45)
+                      (cons (send robot :joint2)  45)
+                      (cons (send robot :joint3)  90)
+                      (cons (send robot :joint4)  45)
+                      (cons (send robot :joint5)   0)
+                      (cons (send robot :joint6)  45)))
+    (setq len (length (send robot :angle-vector)))
+    (setq av (instantiate float-vector len))
+    (objects (list robot))
+    (dotimes (i len)
+      (let* ((j (elt (send robot :joint-list) i))
+             (p (assoc j param))
+             (joint (car p))
+             (angle (cdr p)))
+        (if (and (string= (send j :name) "joint3") ;; for test-revolute-2
+                 (eps= (elt (car (send (j . default-coords) :rpy-angle)) 1) 0.785398))
+            (setq angle 45))
+        (if (derivedp j linear-joint) ;; for test-linear
+            (setq angle (* 10 angle)))
+        (if (or (minusp (elt (j . axis) 0))
+                (minusp (elt (j . axis) 1))
+                (minusp (elt (j . axis) 2)))
+            (setq angle (- angle)))
+        (setf (elt av i) angle)
+        (format t "moving ~A to ~A~%" joint angle)
+        (dotimes (i 10)
+          (send joint :joint-angle (* (+ i 1) 0.1 angle))
+          (send *irtviewer* :draw-objects))
+        (send joint :joint-angle angle)
+        (send *irtviewer* :draw-objects)))
+    ;; check target vector is equal to av
+    (format t "target angle-vector is ~A~%" (send robot :angle-vector))
+    (assert (v= (send robot :angle-vector) av))
+
+    ;; get goal coordinates
+    (setq end-coords (send robot :rarm :end-coords))
+    (send end-coords :draw-on :size 100 :flush t)
+    (setq goal (send end-coords :copy-worldcoords))
+
+    (assert (eps= (elt (send goal :worldpos) 2) 0.0 0.1) "goal should be on the ground ~A" goal)
+    ;; set initial posture
+    (send robot :angle-vector (scale 0.6 av))
+    ;; (send robot :angle-vector (scale 0.0 av))
+
+    ;; start ik
+    (setq *loop* 0)
+    (setq ret (send robot :inverse-kinematics goal :move-target end-coords :stop 20
+                    :debug-view t))
+    (assert ret "ik solved")
+    (format t "ik loop was ~A~%" *loop*)
+    (assert (< *loop* 20) "check loop count ()" *loop*)
+    ))
+
+(deftest test-revolute
+  (test-mimic-joint "revolute-1"))
+
+;; joint3: 45 deg offset
+(deftest test-revolute
+  (test-mimic-joint "revolute-2"))
+
+;; mimic joint2 -> joint3, :y->:y multiply: 2, offset: 0
+(deftest test-revolute-mimic-1
+  (test-mimic-joint "revolute-mimic-1"))
+
+;; mimic joint2 -> joint3, :-y->:y multiply: -2, offset: 0
+(deftest test-revolute-mimic-2
+  (test-mimic-joint "revolute-mimic-2"))
+
+;; mimic joint2 -> joint3, :y->:y multiply: 1, offset: 45
+(deftest test-revolute-mimic-3
+  (test-mimic-joint "revolute-mimic-3"))
+
+;; mimic joint2 -> joint3, :-y->:y multiply: -1, offset: -45
+(deftest test-revolute-mimic-4
+  (test-mimic-joint "revolute-mimic-4"))
+
+;; mimic joint1 -> joint3, :y->:y multiply: 2, offset: 0
+(deftest test-revolute-mimic-5
+  (test-mimic-joint "revolute-mimic-5"))
+
+(deftest test-linear
+  (test-mimic-joint "linear-1"))
+
+(deftest test-linear-mimic-1
+  (test-mimic-joint "linear-mimic-1"))
+
+(deftest test-linear-mimic-2
+  (test-mimic-joint "linear-mimic-2"))
+
+(if (sys:list-all-catchers) ;; called from interpreter (progn (load "test-mimic.l") (test-mimic-joint "linear-mimic-1"))
+    (setq lisp::*exit-on-fatal-error* nil)
+  (progn ;; called as roseus argument `roseus test-mimic.l`
+    (run-all-tests)
+    (exit)))
+

--- a/euscollada/test/test-mimic.test
+++ b/euscollada/test/test-mimic.test
@@ -1,0 +1,5 @@
+<launch>
+  <test test-name="mimic_test" pkg="roseus" type="roseus"
+        args="$(find euscollada)/test/test-mimic.l"
+        />
+</launch>


### PR DESCRIPTION
add mimic-joint-params, rotational-mimic-joint linear-mimic-joint class

![Screenshot from 2019-12-06 20-16-43](https://user-images.githubusercontent.com/493276/70319662-31d51380-1866-11ea-973e-671a74faf860.png)

see `pr2-mimic.sh` for exmaple, it generate codes as follows;

```
     ;; re-define r_gripper_l_finger_joint as mimic-joint
     (let (tmp-mimic-joint)
       (setq tmp-mimic-joint (replace-object (instance rotational-mimic-joint :init :parent-link (make-cascoords) :child-link (make-cascoords) :max-joint-velocity 0 :max-joint-torque 0) r_gripper_l_finger_joint_jt))
       (setq r_gripper_l_finger_joint_jt tmp-mimic-joint))
     (setq (r_gripper_l_finger_joint_jt . mimic-joints)
           (list
            (instance mimic-joint-param :init r_gripper_l_finger_tip_joint_jt :multiplier 1.000000 :offset 0.000000)
            (instance mimic-joint-param :init r_gripper_r_finger_joint_jt :multiplier 1.000000 :offset 0.000000)
            (instance mimic-joint-param :init r_gripper_r_finger_tip_joint_jt :multiplier 1.000000 :offset 0.000000)
            ))

```