### PR TITLE
add world-file-path on README

### DIFF
--- a/eusurdf/README.md
+++ b/eusurdf/README.md
@@ -16,7 +16,7 @@ roseus convert-eus-to-urdf.l
 ;; convert irteus scene to urdf and world file
 ;; some key arguments need to be set
 ;; using (generate-room-models) is recommended to convert room model
-(progn (load "models/room73b2-scene.l") (irteus2urdf-room-for-gazebo (room73b2) "models/room73b2,l"))
+(progn (load "models/room73b2-scene.l") (irteus2urdf-room-for-gazebo (room73b2) "models/room73b2.l"))
 ;; util wrapper function to convert room model
 (generate-room-models "room73b2")
 ```

--- a/eusurdf/README.md
+++ b/eusurdf/README.md
@@ -16,7 +16,7 @@ roseus convert-eus-to-urdf.l
 ;; convert irteus scene to urdf and world file
 ;; some key arguments need to be set
 ;; using (generate-room-models) is recommended to convert room model
-(progn (load "models/room73b2-scene.l") (irteus2urdf-room-for-gazebo (room73b2)))
+(progn (load "models/room73b2-scene.l") (irteus2urdf-room-for-gazebo (room73b2) "models/room73b2,l"))
 ;; util wrapper function to convert room model
 (generate-room-models "room73b2")
 ```


### PR DESCRIPTION
The function `irteus2urdf-room-for-gazebo` requires the [parameter](https://github.com/jsk-ros-pkg/jsk_model_tools/blob/1a46176495c7f8cd3c3483f560072093ec2673ad/eusurdf/euslisp/convert-eus-to-urdf.l#L47), however it didn't write on the readme and this code won't work. So I add the parameter.