### PR TITLE
use https:// instead of git://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".travis"]
 	path = .travis
-	url = git://github.com/jsk-ros-pkg/jsk_travis
+	url = https://github.com/jsk-ros-pkg/jsk_travis


### PR DESCRIPTION
follow up of https://github.com/jsk-ros-pkg/jsk_model_tools/pull/240

- b572a51 (Kei Okada, 72 seconds ago)
    updaete to jsk_travis 0.5.24

    need to use 'use snapshot of rosdep list for eol distros', to support
    indigo check. See https://github.com/jsk-ros-pkg/jsk_travis/pull/437

- d2a86f2 (Naoki-Hiraoka, 21 hours ago)
    use https:// instead of git://

Closes #240 