### PR TITLE
enable to read custom limb name from .yaml file (fix for #249)

### DIFF
--- a/euscollada/pr2_custom_limb.yaml
+++ b/euscollada/pr2_custom_limb.yaml
@@ -1,0 +1,56 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+torso:
+  - torso_lift_joint : torso-waist-z
+larm:
+  - l_shoulder_pan_joint   : larm-collar-y
+  - l_shoulder_lift_joint  : larm-shoulder-p
+  - l_upper_arm_roll_joint : larm-shoulder-r
+  - l_elbow_flex_joint     : larm-elbow-p
+  - l_forearm_roll_joint   : larm-elbow-r
+  - l_wrist_flex_joint     : larm-wrist-p
+  - l_wrist_roll_joint     : larm-wrist-r
+rarm:
+  - r_shoulder_pan_joint   : rarm-collar-y
+  - r_shoulder_lift_joint  : rarm-shoulder-p
+  - r_upper_arm_roll_joint : rarm-shoulder-r
+  - r_elbow_flex_joint     : rarm-elbow-p
+  - r_forearm_roll_joint   : rarm-elbow-r
+  - r_wrist_flex_joint     : rarm-wrist-p
+  - r_wrist_roll_joint     : rarm-wrist-r
+head:
+  - head_pan_joint  : head-neck-y
+  - head_tilt_joint : head-neck-p
+rhand:
+  - r_gripper_r_finger_joint : rhand-r-finger
+  - r_gripper_r_finger_tip_joint : rhand-r-finger-tip
+  - r_gripper_l_finger_joint : rhand-l-finger
+  - r_gripper_l_finger_tip_joint : rhand-l-finger-tip
+lhand:
+  - l_gripper_r_finger_joint : lhand-r-finger
+  - l_gripper_r_finger_tip_joint : lhand-r-finger-tip
+  - l_gripper_l_finger_joint : lhand-l-finger
+  - l_gripper_l_finger_tip_joint : lhand-l-finger-tip
+
+##
+## end-coords
+##
+larm-end-coords: 
+  parent : l_gripper_tool_frame
+  rotate : [0, 1, 0, 00]
+rarm-end-coords:
+  parent : r_gripper_tool_frame
+  rotate : [0, 1, 0, 00]
+head-end-coords:
+  translate : [0.08, 0, 0.13]
+  rotate    : [0, 1, 0, 90]
+
+##
+## reset-pose
+##
+angle-vector:
+  reset-manip-pose : [300.0, 75.0, 50.0, 110.0, -110.0, -20.0, -10.0, -10.0, -75.0, 50.0, -110.0, -110.0, 20.0, -10.0, -10.0, 0.0, 50.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+  reset-pose : [50.0, 60.0, 74.0, 70.0, -120.0, 20.0, -30.0, 180.0, -60.0, 74.0, -70.0, -120.0, -20.0, -30.0, 180.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+

--- a/euscollada/src/collada2eus_urdfmodel.cpp
+++ b/euscollada/src/collada2eus_urdfmodel.cpp
@@ -591,9 +591,9 @@ void ModelEuslisp::printMesh(const aiScene* scene, const aiNode* node, const Vec
 }
 
 bool limb_order_asc(const pair<string, size_t>& left, const pair<string, size_t>& right) { return left.second < right.second; }
- void ModelEuslisp::readYaml (std::vector<string> &config_files) {
+void ModelEuslisp::readYaml (std::vector<string> &config_files) {
   // read yaml
-  std::vector<string> limb_candidates;  // limb names is given from yaml fiels
+  std::vector<string> limb_candidates;  // limb names is given from yaml files
 
   vector<pair<string, size_t> > limb_order;
 
@@ -621,9 +621,9 @@ bool limb_order_asc(const pair<string, size_t>& left, const pair<string, size_t>
   }
 
   {
-    // set limb_candidates from yaml fiels
+    // set limb_candidates from yaml files
     for(YAML::const_iterator it=doc.begin();it != doc.end();++it) {
-      // -end-coords, *-vector
+      // -end-coords, *-vector, sensors
       if ( boost::algorithm::ends_with(it->first.as<std::string>(), "-coords") ||
            boost::algorithm::ends_with(it->first.as<std::string>(), "-vector") ||
            it->first.as<std::string>() == "sensors") {

--- a/euscollada/src/collada2eus_urdfmodel.cpp
+++ b/euscollada/src/collada2eus_urdfmodel.cpp
@@ -644,8 +644,8 @@ void ModelEuslisp::readYaml (string &config_file) {
   }
 
   // generate limbs including limb_name, link_names, and joint_names
-  for (size_t i = 0; i < limb_order.size(); i++) {
-    string limb_name = limb_order[i].first;
+  for (size_t l = 0; l < limb_order.size(); l++) {
+    string limb_name = limb_order[l].first;
     vector<string> tmp_link_names, tmp_joint_names;
     try {
       const YAML::Node& limb_doc = doc[limb_name];

--- a/euscollada/test/euscollada-model-conversion-test.l
+++ b/euscollada/test/euscollada-model-conversion-test.l
@@ -58,6 +58,18 @@
 (deftest pr2-eusmodel-validity-check
   (eusmodel-validity-check-one *pr2*))
 
+(deftest generate-pr2-custom-limb-test
+  (generate-eusmodel-from-collada "/tmp/pr2.dae" "/tmp/pr2_custom_limb.l"
+                                  :yaml-file "$(rospack find euscollada)/pr2_custom_limb.yaml")
+  (assert (probe-file "/tmp/pr2_custom_limb.l") ";; faild to generate /tmp/pr2_custom_limb.l, file does not exist")
+  (load "/tmp/pr2_custom_limb.l")
+  (pr2)
+  (eusmodel-validity-check-one *pr2*)
+  (send *pr2* :reset-pose)
+  (assert (equal (send-all (send *pr2* :rhand :joint-list) :name) (list "r_gripper_r_finger_joint" "r_gripper_r_finger_tip_joint" "r_gripper_l_finger_joint" "r_gripper_l_finger_tip_joint")))
+  (assert (subsetp (send *pr2* :rhand :joint-list) (send *pr2* :joint-list) :test #'equal))
+  )
+
 (deftest generate-sample-robot-model-test
  (when (ros::rospack-find "openhrp3")
   (generate-eusmodel-from-collada

--- a/euscollada/test/euscollada-model-conversion-test.l
+++ b/euscollada/test/euscollada-model-conversion-test.l
@@ -4,11 +4,18 @@
 
 (defun generate-eusmodel-from-collada (col-file eus-file &key (yaml-file))
   (let ((strm (piped-fork
-               (if yaml-file
-                   (format nil "rosrun euscollada collada2eus ~A ~A ~A && echo finished"
-                           col-file yaml-file eus-file)
-                 (format nil "rosrun euscollada collada2eus ~A ~A && echo finished"
-                         col-file eus-file)))))
+               (cond ((stringp yaml-file)
+                      (format nil "rosrun euscollada collada2eus ~A ~A ~A && echo finished"
+                              col-file yaml-file eus-file))
+                     ((null yaml-file)
+                      (format nil "rosrun euscollada collada2eus ~A ~A && echo finished"
+                              col-file eus-file))
+                     (t ;; list of filename
+                      (concatenate string
+                                   (format nil "rosrun euscollada collada2eus -I ~A -O ~A -C "
+                                           col-file eus-file)
+                                   (apply #'concatenate string (mapcar #'(lambda (f) (format nil "~A " f)) yaml-file))
+                                   "&& echo finished"))))))
     ;; (assert (select-stream (list strm) 240) (format nil ";; faild to generate ~A within 240 second" eus-file)) ;; why return nil immidiately
     (dotimes (i 240)
       (when
@@ -86,6 +93,24 @@
   (assert (eps= 1.308000e+05 (send *samplerobot* :weight))
           ";; sample robot has not valid weight ~A" (send *samplerobot* :weight))
   (assert (eps-v= #f(2.32416 0.0 68.4419) (send *samplerobot* :centroid))
+          ";; sample robot has not valid centroid ~A" (send *samplerobot* :centroid))
+  ))
+
+(deftest generate-sample-robot-multi-yaml-test
+ (when (ros::rospack-find "openhrp3")
+  (generate-eusmodel-from-collada
+   "$(rospack find openhrp3)/share/OpenHRP-3.1/sample/model/sample1.dae"
+   "/tmp/samplerobot_multi_yaml.l" :yaml-file (list "$(rospack find euscollada)/test/samplerobot1.yaml" "$(rospack find euscollada)/test/samplerobot2.yaml"))
+
+  (assert (probe-file "/tmp/samplerobot_multi_yaml.l") ";; faild to generate /tmp/samplerobot_multi_yaml.l, file does not exist")
+  (load "/tmp/samplerobot_multi_yaml.l")
+  (samplerobot)
+  (send *samplerobot* :init-pose)
+  (eusmodel-validity-check-one *samplerobot*)
+  (send *samplerobot* :fix-leg-to-coords (make-coords))
+  (assert (eps= 1.308000e+05 (send *samplerobot* :weight))
+          ";; sample robot has not valid weight ~A" (send *samplerobot* :weight))
+  (assert (eps-v= #f(2.32416 0.0 791.942) (send *samplerobot* :centroid))
           ";; sample robot has not valid centroid ~A" (send *samplerobot* :centroid))
   ))
 

--- a/euscollada/test/samplerobot1.yaml
+++ b/euscollada/test/samplerobot1.yaml
@@ -1,0 +1,79 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+rleg:
+  - RLEG_HIP_R      : rleg-crotch-r
+  - RLEG_HIP_P      : rleg-crotch-p
+  - RLEG_HIP_Y      : rleg-crotch-y
+  - RLEG_KNEE       : rleg-knee-p
+  - RLEG_ANKLE_P    : rleg-ankle-p
+  - RLEG_ANKLE_R    : rleg-ankle-r
+rarm:
+  - RARM_SHOULDER_P : rarm-shoulder-p
+  - RARM_SHOULDER_R : rarm-shoulder-r
+  - RARM_SHOULDER_Y : rarm-shoulder-y
+  - RARM_ELBOW      : rarm-elbow-p
+  - RARM_WRIST_Y    : rarm-wrist-y
+  - RARM_WRIST_P    : rarm-wrist-p
+  - RARM_WRIST_R    : rarm-wrist-r
+lleg:
+  - LLEG_HIP_R      : lleg-crotch-r
+  - LLEG_HIP_P      : lleg-crotch-p
+  - LLEG_HIP_Y      : lleg-crotch-y
+  - LLEG_KNEE       : lleg-knee-p
+  - LLEG_ANKLE_P    : lleg-ankle-p
+  - LLEG_ANKLE_R    : lleg-ankle-r
+larm:
+  - LARM_SHOULDER_P : larm-shoulder-p
+  - LARM_SHOULDER_R : larm-shoulder-r
+  - LARM_SHOULDER_Y : larm-shoulder-y
+  - LARM_ELBOW      : larm-elbow-p
+  - LARM_WRIST_Y    : larm-wrist-y
+  - LARM_WRIST_P    : larm-wrist-p
+  - LARM_WRIST_R    : larm-wrist-r
+torso:
+  - WAIST_P      : torso-waist-p
+  - WAIST_R      : torso-waist-r
+  - CHEST        : torso-waist-y
+
+##
+## end-coords
+##
+larm-end-coords:
+  translate : [0, 0, -0.12]
+  rotate    : [0, 1,  0, 90]
+  parent    : LARM_LINK6
+rarm-end-coords:
+  translate : [0, 0, -0.12]
+  rotate    : [0, 1,  0, 90]
+  parent    : RARM_LINK6
+lleg-end-coords:
+  translate : [0.00, 0, -0.07]
+rleg-end-coords:
+  translate : [0.00, 0, -0.07]
+head-end-coords:
+  translate : [0.08, 0, 0.13]
+  rotate    : [0, 1, 0, 90]
+
+##
+## reset-pose
+##
+angle-vector:
+# old reset-pose
+#  reset-pose : [0.0, -20.0, 0.0, 47.0, -27.0, 0.0, # rleg
+#                30.0, 0.0, 0.0, -60.0,  9.0, -6.5,  36.5, # rarm
+#                0.0, -20.0, 0.0, 47.0, -27.0, 0.0, # lleg
+#                30.0, 0.0, 0.0, -60.0, -9.0, -6.5, -36.5, # larm
+#                0.0, 0.0, 0.0] # torso
+  # openhrp reset pose from the initial line of OpenHRP-3.1/sample/controller/SampleController/etc/Sample.pos
+  reset-pose : [-0.004457, -21.6929, -0.01202, 47.6723, -25.93, 0.014025, # rleg
+                17.8356, -9.13759, -6.61188, -36.456, 0.0, 0.0, 0.0, # rarm
+                -0.004457, -21.6929, -0.01202, 47.6723, -25.93, 0.014025, # lleg
+                17.8356, 9.13759, 6.61188, -36.456, 0.0, 0.0, 0.0, # larm
+                0.0, 0.0, 0.0] # torso
+  reset-manip-pose : [0.0, -20.0, 0.0, 47.0, -27.0, 0.0, # rleg
+                     30.0, 0.0, 0.0, -100.0,  9.0, -6.5,  36.5, # rarm
+                     0.0, -20.0, 0.0, 47.0, -27.0, 0.0, # lleg
+                     30.0, 0.0, 0.0, -100.0, -9.0, -6.5, -36.5, # larm
+                     0.0, 0.0, 0.0] # torso

--- a/euscollada/test/samplerobot2.yaml
+++ b/euscollada/test/samplerobot2.yaml
@@ -1,0 +1,20 @@
+# for gazebo simulation
+replace_xmls:
+  - match_rule:
+      tag: gazebo
+      attribute_name: reference
+      attribute_value: LLEG_LINK6
+    replaced_xml: '<gazebo reference="LLEG_LINK6">\n    <kp>1000000.0</kp>\n    <kd>100.0</kd>\n    <mu1>1.5</mu1>\n    <mu2>1.5</mu2>\n    <fdir1>1 0 0</fdir1>\n    <maxVel>10.0</maxVel>\n    <minDepth>0.00</minDepth>\n  </gazebo>'
+  - match_rule:
+      tag: gazebo
+      attribute_name: reference
+      attribute_value: RLEG_LINK6
+    replaced_xml: '<gazebo reference="RLEG_LINK6">\n    <kp>1000000.0</kp>\n    <kd>100.0</kd>\n    <mu1>1.5</mu1>\n    <mu2>1.5</mu2>\n    <fdir1>1 0 0</fdir1>\n    <maxVel>10.0</maxVel>\n    <minDepth>0.00</minDepth>\n  </gazebo>'
+  - match_rule:
+      attribute_name: effort
+      attribute_value: 100
+    replaced_attribute_value: 200
+  - match_rule:
+      attribute_name: velocity
+      attribute_value: 0.5
+    replaced_attribute_value: 6.0


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_model_tools/pull/249 に、

- 複数yamlを読み込む機能
- replace_xmlsなどのキーをlimbと誤って解釈しないようにする修正

を追加しました。