### PR TITLE
[collada2eus_urdfmodel.cpp] print links in the order of link names

### DIFF
--- a/euscollada/src/collada2eus_urdfmodel.cpp
+++ b/euscollada/src/collada2eus_urdfmodel.cpp
@@ -307,14 +307,24 @@ private:
 #endif
   string arobot_name;
 #if URDFDOM_1_0_0_API
-  map <LinkConstSharedPtr, Pose > m_link_coords;
-  map <LinkConstSharedPtr, MapVisual > m_link_visual;
-  map <LinkConstSharedPtr, MapCollision > m_link_collision;
+  struct LinkPtrComparator {
+    bool operator()(const LinkConstSharedPtr & left, const LinkConstSharedPtr & right) const {
+      return (left->name < right->name);
+    }
+  };
+  map <LinkConstSharedPtr, Pose, LinkPtrComparator > m_link_coords;
+  map <LinkConstSharedPtr, MapVisual, LinkPtrComparator > m_link_visual;
+  map <LinkConstSharedPtr, MapCollision, LinkPtrComparator > m_link_collision;
   map <string, MaterialConstSharedPtr> m_materials;
 #else
-  map <boost::shared_ptr<const Link>, Pose > m_link_coords;
-  map <boost::shared_ptr<const Link>, MapVisual > m_link_visual;
-  map <boost::shared_ptr<const Link>, MapCollision > m_link_collision;
+  struct LinkPtrComparator {
+    bool operator()(const boost::shared_ptr<const Link> & left, const boost::shared_ptr<const Link> & right) const {
+      return (left->name < right->name);
+    }
+  };
+  map <boost::shared_ptr<const Link>, Pose, LinkPtrComparator > m_link_coords;
+  map <boost::shared_ptr<const Link>, MapVisual, LinkPtrComparator > m_link_visual;
+  map <boost::shared_ptr<const Link>, MapCollision, LinkPtrComparator > m_link_collision;
   map <string, boost::shared_ptr<const Material> > m_materials;
 #endif
   vector<pair<string, string> > g_all_link_names;


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_model_tools/pull/250#issuecomment-1510515482 に対応したPull Requestです。

これまで、collada2eusのソースコードに変更を加える度に、生成されるeusモデルのリンクの宣言順が変わってしまって、生成されるeusモデルに大きなdiffが発生してしまい、collada2eusに加えた変更が妥当かどうかの検証がしづらい、という問題が有りました。

考えられる原因は、次のとおりです。

collada2eusは、https://github.com/jsk-ros-pkg/jsk_model_tools/blob/6749740bdb803cdaeb4d453e086b805f05b6c030/euscollada/src/collada2eus_urdfmodel.cpp#L777-L781 やhttps://github.com/jsk-ros-pkg/jsk_model_tools/blob/6749740bdb803cdaeb4d453e086b805f05b6c030/euscollada/src/collada2eus_urdfmodel.cpp#L1862-L1866 で、linkのshared_ptrをキーとするmapにlinkが格納されていて、mapのイテレータを回したときにどのような順番になっているかによって、linkの宣言順番が決まっています。mapのイテレータの順番は、デフォルトだと恐らくlinkのアドレス順になるので、linkのメモリを確保するときにどのアドレスに確保されたかに依存すると思われます。そのため、collada2eusのソースコードに変更を加えると、変更した部分で行うメモリ確保・開放がlinkのアドレスに何らかの影響を与えて、linkの宣言順番が変化してしまっているのではないかと思います。

このPull Reqeustは、mapのイテレータを回したときに、リンク名のアルファベット順で回るように変更することで、この問題を解決するものです。