### PR TITLE
[collada2eus_urdfmodel.cpp] change joint-angle range based on joint->mimic->multiplier

### DIFF
--- a/euscollada/src/collada2eus_urdfmodel.cpp
+++ b/euscollada/src/collada2eus_urdfmodel.cpp
@@ -1038,6 +1038,16 @@ void ModelEuslisp::printJoint (boost::shared_ptr<const Joint> joint) {
     if (joint->type ==Joint::CONTINUOUS) {
       fprintf(fp, "                     :min *-inf* :max *inf*\n");
     } else {
+      if (joint->mimic) {
+        if (joint->mimic->multiplier < 0) {
+          float min_tmp = max * joint->mimic->multiplier;
+          max = min * joint->mimic->multiplier;
+          min = min_tmp;
+        } else {
+          min = min * joint->mimic->multiplier;
+          max = max * joint->mimic->multiplier;
+        }
+      }
       fprintf(fp, ":min ");
       if (min == -FLT_MAX) fprintf(fp, "*-inf*"); else
         fprintf(fp, "%f", joint->type ==Joint::PRISMATIC ? min * 1000 : min * 180.0 / M_PI);


### PR DESCRIPTION
![image](https://github.com/jsk-ros-pkg/jsk_model_tools/assets/35333281/181b3f02-385e-4d3a-9b90-01a52842743a)
When the multiplier of the mimic joint is `minus`, for example the _left_inner_finger_joint_ of [robotiq_2f_85_girpper](https://github.com/ros-industrial/robotiq/tree/kinetic-devel/robotiq_2f_85_gripper_visualization), its corresponding joint angle range should be modified as:
```
min = max * multiplier
max = min * multiplier
```

Or, the generated euslisp file from euscollada still has the original range without multiplier considered, continuously causing warning whenever send angle-vector to the robot model.
![image](https://github.com/jsk-ros-pkg/jsk_model_tools/assets/35333281/1bdcb75b-1f21-4318-88ef-2f9e6f28300c)


With this PR, joint-angle ranges of mimic joints can be modified based on their multipliers, and there's no more warning with the generated euslisp file.
![image](https://github.com/jsk-ros-pkg/jsk_model_tools/assets/35333281/554da1ad-7e9f-48b2-a484-e8416f022237)

Code can be tested as follows:
```
mkdir -p ~/catkin_ws/src
cd ~/catkin_ws/src
sudo apt-get install ros-<distro>-ur-description
git clone https://github.com/ros-industrial/robotiq.git
git clone https://gitlab.jsk.imi.i.u-tokyo.ac.jp/tendon/mujoco_ros_interface.git
git clone https://github.com/W567/jsk_model_tools.git
# or git clone https://github.com/jsk-ros-pkg/jsk_model_tools.git
git clone https://github.com/jsk-ros-pkg/jsk_pr2eus.git

cd ~/catkin
catkin build ur5e85
source ~/catkin/devel/setup.bash
roscd ur5e85/euslisp
# roscore at another terminal
roseus ur5e85-interface.l
  ur5e85-init
  send *sr* :angle-vector #f(0 0 0 0 0 0 20)
```